### PR TITLE
Instance methods for provided operations

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -43,4 +43,4 @@ group Test
 	nuget NUnit.Console
 	nuget FSharp.Data
 
-	github fsprojects/FsUnit src/FsUnit.NUnit/FsUnit.fs
+	github fsprojects/FsUnit src/FsUnit.NUnit/FsUnitTyped.fs

--- a/paket.lock
+++ b/paket.lock
@@ -18,9 +18,9 @@ GITHUB
     src/Net/UriUtils.fs (f815de5e8108bb7de25dde75135707719afd8e09)
   remote: fsprojects/FSharp.TypeProviders.StarterPack
   specs:
-    src/ProvidedTypes.fs (ddfb906ecbac78dc9f0f5e172518a72cb5fdf651)
-    src/ProvidedTypes.fsi (ddfb906ecbac78dc9f0f5e172518a72cb5fdf651)
-    src/ProvidedTypesTesting.fs (ddfb906ecbac78dc9f0f5e172518a72cb5fdf651)
+    src/ProvidedTypes.fs (ea733039c168a8e2d441e298a1c67d98f63b00f6)
+    src/ProvidedTypes.fsi (ea733039c168a8e2d441e298a1c67d98f63b00f6)
+    src/ProvidedTypesTesting.fs (ea733039c168a8e2d441e298a1c67d98f63b00f6)
   remote: fsprojects/FSharp.Configuration
   specs:
     src/FSharp.Configuration/TypeProviders.Helper.fs (763182e36f2dbd30e99743eb595019efda1b7697)
@@ -28,7 +28,7 @@ GROUP Build
 NUGET
   remote: https://www.nuget.org/api/v2
   specs:
-    FAKE (4.24)
+    FAKE (4.25.4)
     FSharp.Compiler.Service (2.0.0.6)
     FSharp.Formatting (2.14.2)
       FSharp.Compiler.Service (2.0.0.6)
@@ -47,7 +47,7 @@ NUGET
 GITHUB
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (b25845256f838c2dd568b2f92bdf64d5425f8a43)
+    modules/Octokit/Octokit.fsx (8f3531f4c47b86e51b4e32409bd760f79a555c62)
       Octokit
 GROUP OWIN
 NUGET
@@ -105,4 +105,4 @@ NUGET
 GITHUB
   remote: fsprojects/FsUnit
   specs:
-    src/FsUnit.NUnit/FsUnit.fs (43086ca8981c7642c1067ad5e9de80caf73ba4ec)
+    src/FsUnit.NUnit/FsUnitTyped.fs (43086ca8981c7642c1067ad5e9de80caf73ba4ec)

--- a/src/SwaggerProvider.DesignTime/DefinitionCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/DefinitionCompiler.fs
@@ -105,11 +105,8 @@ type DefinitionCompiler (schema:SwaggerObject) =
 
     /// Compiles the definition.
     member __.GetProvidedTypes() =
-        let root = ProvidedTypeDefinition("Definitions", Some typeof<obj>, IsErased = false)
-        root.AddMembersDelayed (fun () ->
-            List.ofSeq providedTys.Values
-            |> List.choose (id))
-        root
+        List.ofSeq providedTys.Values
+        |> List.choose (id)
 
     /// Compiles the definition.
     member __.CompileTy opName tyUseSuffix ty required =

--- a/src/SwaggerProvider.DesignTime/SwaggerProviderConfig.fs
+++ b/src/SwaggerProvider.DesignTime/SwaggerProviderConfig.fs
@@ -71,13 +71,11 @@ module private SwaggerProviderConfig =
 
                         let ctor =
                             ProvidedConstructor(
-                                [ProvidedParameter("host", typeof<string>, optionalValue = true) //schema.Host
-                                 ProvidedParameter("headers", typeof<(string*string)[]>, optionalValue = true)//Array.empty<string*string>
-                                 ProvidedParameter("customizeHttpRequest", typeof<Net.HttpWebRequest -> Net.HttpWebRequest>, optionalValue = true)], // id
+                                [ProvidedParameter("host", typeof<string>, optionalValue = schema.Host)],
                                 InvokeCode = fun args ->
                                     match args with
                                     | [] -> failwith "Generated constructors should always pass the instance as the first argument!"
-                                    | this::_ -> Expr.Coerce(this, ty))//<@@ () @@>)
+                                    | _ -> <@@ () @@>)
                         ctor.BaseConstructorCall <-
                             let baseCtor = baseTy.Value.GetConstructors().[0]
                             fun args -> (baseCtor, args)

--- a/src/SwaggerProvider.DesignTime/SwaggerProviderConfig.fs
+++ b/src/SwaggerProvider.DesignTime/SwaggerProviderConfig.fs
@@ -22,12 +22,15 @@ module private SwaggerProviderConfig =
 
         let staticParams =
             [ ProvidedStaticParameter("Schema", typeof<string>)
-              ProvidedStaticParameter("Headers", typeof<string>,"")]
+              ProvidedStaticParameter("Headers", typeof<string>,"")
+              ProvidedStaticParameter("IgnoreOperationId", typeof<bool>, false)]
 
+        //TODO: Add use operationID flag
         swaggerProvider.AddXmlDoc
             """<summary>Statically typed Swagger provider.</summary>
                <param name='Schema'>Url or Path to Swagger schema file.</param>
-               <param name='Headers'>Headers that will be added to all HTTP requests.</param>"""
+               <param name='Headers'>Headers that will be used to access the schema.</param>
+               <param name='IgnoreOperationId'>IgnoreOperationId tells SwaggerProvider not to use `operationsId` and generate method names using `path` only. Default value `false`</param>"""
 
         let cache = new MemoryCache("SwaggerProvider")
         context.AddDisposable cache
@@ -36,52 +39,54 @@ module private SwaggerProviderConfig =
                 parameters=staticParams,
                 instantiationFunction = (fun typeName args ->
                     let value = lazy (
-                        let h = args.[1] :?> string
-                        let headers = h.Split('|') |> Seq.filter (fun f -> f.Contains("=")) |> Seq.map (fun e ->
-                            let pair = e.Split('=')
-                            (pair.[0],pair.[1])
-                            )
-
                         let schemaPathRaw = args.[0] :?> string
+                        let ignoreOperationId = args.[2] :?> bool
 
                         let schemaData =
                             match schemaPathRaw.StartsWith("http", true, null) with
-                            | true ->
-                                Http.RequestString(schemaPathRaw)
+                            | true  ->
+                                let headersStr = args.[1] :?> string
+                                let headers =
+                                    headersStr.Split('|')
+                                    |> Seq.choose (fun x ->
+                                        let pair = x.Split('=')
+                                        if (pair.Length = 2)
+                                        then Some (pair.[0],pair.[1])
+                                        else None
+                                    )
+                                Http.RequestString(schemaPathRaw, headers=headers)
                             | false ->
                                 context.WatchFile schemaPathRaw
                                 schemaPathRaw |> IO.File.ReadAllText
 
-                        let stringParser =
-                            if schemaData.Trim().StartsWith("{")
-                                then JsonValue.Parse >> JsonNodeAdapter >> (fun x -> x :> SchemaNode)
-                                else YamlParser.Parse >> YamlNodeAdapter >> (fun x -> x :> SchemaNode)
-
                         let schema =
-                            schemaData
-                            |> stringParser
-                            |> Parser.parseSwaggerObject
+                            if schemaData.Trim().StartsWith("{")
+                            then JsonValue.Parse  schemaData |> JsonNodeAdapter |> Parser.parseSwaggerObject
+                            else YamlParser.Parse schemaData |> YamlNodeAdapter |> Parser.parseSwaggerObject
 
                         // Create Swagger provider type
-                        let ty = ProvidedTypeDefinition(asm, NameSpace, typeName, Some typeof<obj>, IsErased = false)
+                        let baseTy = Some typeof<SwaggerProvider.Internal.ProvidedSwaggerBaseType>
+                        let ty = ProvidedTypeDefinition(asm, NameSpace, typeName, baseTy, IsErased = false)
                         ty.AddXmlDoc ("Swagger.io Provider for " + schema.Host)
 
-                        let defaultHost = schema.Host
-                        let hostProperty =
-                            ProvidedProperty(
-                                propertyName = "Host",
-                                propertyType = typeof<string>,
-                                IsStatic = true,
-                                GetterCode = (function _ ->
-                                    <@@ SwaggerProvider.Internal.RuntimeHelpers.getHost schemaPathRaw defaultHost @@>),
-                                SetterCode = (function args ->
-                                    <@@ SwaggerProvider.Internal.RuntimeHelpers.setHost schemaPathRaw (%%args.[0] : string) @@>))
-                        ty.AddMember hostProperty
+                        let ctor =
+                            ProvidedConstructor(
+                                [ProvidedParameter("host", typeof<string>, optionalValue = true) //schema.Host
+                                 ProvidedParameter("headers", typeof<(string*string)[]>, optionalValue = true)//Array.empty<string*string>
+                                 ProvidedParameter("customizeHttpRequest", typeof<Net.HttpWebRequest -> Net.HttpWebRequest>, optionalValue = true)], // id
+                                InvokeCode = fun args ->
+                                    match args with
+                                    | [] -> failwith "Generated constructors should always pass the instance as the first argument!"
+                                    | this::_ -> Expr.Coerce(this, ty))//<@@ () @@>)
+                        ctor.BaseConstructorCall <-
+                            let baseCtor = baseTy.Value.GetConstructors().[0]
+                            fun args -> (baseCtor, args)
+                        ty.AddMember ctor
 
                         let defCompiler = DefinitionCompiler(schema)
-                        let opCompiler = OperationCompiler(schema, defCompiler, headers)
-                        ty.AddMembers <| opCompiler.Compile(schemaPathRaw) // Add all operations
-                        ty.AddMember  <| defCompiler.GetProvidedTypes() // Add all compiled types
+                        let opCompiler = OperationCompiler(schema, defCompiler)
+                        ty.AddMembers <| opCompiler.CompilePaths(ignoreOperationId) // Add all operations
+                        ty.AddMembers <| defCompiler.GetProvidedTypes() // Add all compiled types
 
                         let tempAsmPath = System.IO.Path.ChangeExtension(System.IO.Path.GetTempFileName(), ".dll")
                         let tempAsm = ProvidedAssembly tempAsmPath

--- a/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
+++ b/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
@@ -4,6 +4,12 @@ open System
 open Newtonsoft.Json
 open Microsoft.FSharp.Reflection
 
+type ProvidedSwaggerBaseType
+    (host:string, headers:(string*string)[], customizeHttpRequest: Net.HttpWebRequest -> Net.HttpWebRequest) =
+    member val Host = host with get, set
+    member val Headers = headers with get, set
+    member val CustomizeHttpRequest = customizeHttpRequest with get, set
+
 /// Serializer for serializing the F# option types.
 // https://github.com/eulerfx/JsonNet.FSharp
 type private OptionConverter() =
@@ -31,16 +37,6 @@ type private OptionConverter() =
         else FSharpValue.MakeUnion(cases.[1], [|value|])
 
 module RuntimeHelpers =
-    // Storage for Host values in runtime
-    let hostUrls = System.Collections.Generic.Dictionary<string,string>()
-    let getHost schemaId defaultHost =
-        match hostUrls.TryGetValue(schemaId) with
-        | true, value -> value
-        | _ -> defaultHost
-    let setHost schemaId value =
-        hostUrls.Remove(schemaId) |> ignore
-        hostUrls.Add(schemaId, value)
-
 
     let inline private toStrArray name values =
         values

--- a/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
+++ b/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
@@ -4,11 +4,10 @@ open System
 open Newtonsoft.Json
 open Microsoft.FSharp.Reflection
 
-type ProvidedSwaggerBaseType
-    (host:string, headers:(string*string)[], customizeHttpRequest: Net.HttpWebRequest -> Net.HttpWebRequest) =
+type ProvidedSwaggerBaseType (host:string) =
     member val Host = host with get, set
-    member val Headers = headers with get, set
-    member val CustomizeHttpRequest = customizeHttpRequest with get, set
+    member val Headers = Array.empty<string*string> with get, set
+    member val CustomizeHttpRequest = (id:Net.HttpWebRequest -> Net.HttpWebRequest) with get, set
 
 /// Serializer for serializing the F# option types.
 // https://github.com/eulerfx/JsonNet.FSharp

--- a/tests/SwaggerProvider.ProviderTests/Swagger.GitHub.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swagger.GitHub.Tests.fs
@@ -7,7 +7,7 @@ open FsUnitTyped
 
 let [<Literal>] Schema = __SOURCE_DIRECTORY__ + "/Schemas/GitHub.json"
 type GitHubTy = SwaggerProvider<Schema>
-let GitHub = GitHubTy("api.github.com", [|"User-Agent","Mozilla/5.0 (iPad; U; CPU OS 3_2_1 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Mobile/7B405"|])
+let GitHub = GitHubTy("api.github.com", Headers = [|"User-Agent","Mozilla/5.0 (iPad; U; CPU OS 3_2_1 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Mobile/7B405"|])
 
 [<Test; Explicit>]
 let ``Get fsprojects from GitHub`` () =

--- a/tests/SwaggerProvider.ProviderTests/Swagger.GitHub.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swagger.GitHub.Tests.fs
@@ -3,15 +3,14 @@
 open SwaggerProvider
 open FSharp.Data
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 
-let [<Literal>] schema = __SOURCE_DIRECTORY__ + "/Schemas/GitHub.json"
-let [<Literal>] headers = "User-Agent=Mozilla/5.0 (iPad; U; CPU OS 3_2_1 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Mobile/7B405"
-type GitHub = SwaggerProvider<schema, headers>
-GitHub.Host <- "api.github.com"
+let [<Literal>] Schema = __SOURCE_DIRECTORY__ + "/Schemas/GitHub.json"
+type GitHubTy = SwaggerProvider<Schema>
+let GitHub = GitHubTy("api.github.com", [|"User-Agent","Mozilla/5.0 (iPad; U; CPU OS 3_2_1 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Mobile/7B405"|])
 
 [<Test; Explicit>]
 let ``Get fsprojects from GitHub`` () =
-    GitHub.Repos.OrgRepos("fsprojects").Length
-    |> should be (greaterThan 0)
+    GitHub.OrgRepos("fsprojects").Length
+    |> shouldBeGreaterThan 0
 

--- a/tests/SwaggerProvider.ProviderTests/Swagger.Instagram.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swagger.Instagram.Tests.fs
@@ -5,4 +5,4 @@ open SwaggerProvider
 let [<Literal>] Schema = __SOURCE_DIRECTORY__ + "/Schemas/Instagram.json"
 type Instagram = SwaggerProvider<Schema>
 
-let insta = Instagram()
+let insta = Instagram(Headers=[||], CustomizeHttpRequest=id)

--- a/tests/SwaggerProvider.ProviderTests/Swagger.Instagram.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swagger.Instagram.Tests.fs
@@ -2,6 +2,7 @@
 
 open SwaggerProvider
 
-let [<Literal>] schema = __SOURCE_DIRECTORY__ + "/Schemas/Instagram.json"
-type Instagram = SwaggerProvider<schema>
+let [<Literal>] Schema = __SOURCE_DIRECTORY__ + "/Schemas/Instagram.json"
+type Instagram = SwaggerProvider<Schema>
 
+let insta = Instagram()

--- a/tests/SwaggerProvider.ProviderTests/Swagger.PetStore.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swagger.PetStore.Tests.fs
@@ -3,46 +3,47 @@
 open SwaggerProvider
 open FSharp.Data
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 
 type PetStore = SwaggerProvider<"http://petstore.swagger.io/v2/swagger.json", "Content-Type=application/json">
+let store = PetStore()
 
 let apiKey = "special-key"
 
 [<Test>]
 let ``Test provided Host property`` () =
-    PetStore.Host |> should equal "petstore.swagger.io"
-    PetStore.Host <- "test"
-    PetStore.Host |> should equal "test"
-    PetStore.Host <- "petstore.swagger.io"
-    PetStore.Host |> should equal "petstore.swagger.io"
+    store.Host |> shouldEqual "petstore.swagger.io"
+    store.Host <- "test"
+    store.Host |> shouldEqual "test"
+    store.Host <- "petstore.swagger.io"
+    store.Host |> shouldEqual "petstore.swagger.io"
 
 [<Test>]
 let ``instantiate provided objects`` () =
-    let pet = PetStore.Definitions.Pet(Name = "foo")
-    pet.Name |> should equal "foo"
+    let pet = PetStore.Pet(Name = "foo")
+    pet.Name |> shouldEqual "foo"
     pet.Name <- "bar"
-    pet.Name |> should equal "bar"
+    pet.Name |> shouldEqual "bar"
 
 [<Test>]
 let ``call provided methods`` () =
     try
-        PetStore.Pet.DeletePet(1337L, apiKey)
+        store.DeletePet(1337L, apiKey)
     with
     | exn -> ()
 
-    let tag = PetStore.Definitions.Tag (Name = "foobar")
-    let pet = PetStore.Definitions.Pet (Name = "foo", Id = Some 1337L, Status = "available")
+    let tag = PetStore.Tag (Name = "foobar")
+    let pet = PetStore.Pet (Name = "foo", Id = Some 1337L, Status = "available")
 
     try
-        PetStore.Pet.AddPet(pet)
+        store.AddPet(pet)
     with
     | exn -> Assert.Fail ("Adding pet failed with message: " + exn.Message)
 
-    let pet2 = PetStore.Pet.GetPetById(1337L)
-    pet.Name        |> should equal pet2.Name
-    pet.Id          |> should equal pet.Id
-    pet.Category    |> should equal pet2.Category
-    pet.Status      |> should equal pet2.Status
-    pet             |> should not' (equal pet2)
+    let pet2 = store.GetPetById(1337L)
+    pet.Name        |> shouldEqual pet2.Name
+    pet.Id          |> shouldEqual pet.Id
+    pet.Category    |> shouldEqual pet2.Category
+    pet.Status      |> shouldEqual pet2.Status
+    pet             |> shouldNotEqual pet2
 

--- a/tests/SwaggerProvider.ProviderTests/SwaggerProvider.ProviderTests.fsproj
+++ b/tests/SwaggerProvider.ProviderTests/SwaggerProvider.ProviderTests.fsproj
@@ -65,9 +65,9 @@
   -->
   <Import Project="..\..\.paket\paket.targets" />
   <ItemGroup>
-    <Compile Include="..\..\paket-files\test\fsprojects\FsUnit\src\FsUnit.NUnit\FsUnit.fs">
+    <Compile Include="..\..\paket-files\test\fsprojects\FsUnit\src\FsUnit.NUnit\FsUnitTyped.fs">
       <Paket>True</Paket>
-      <Link>paket-files/FsUnit.fs</Link>
+      <Link>paket-files/FsUnitTyped.fs</Link>
     </Compile>
     <Content Include="Schemas\GitHub.json">
       <Link>Schemas/GitHub.json</Link>

--- a/tests/SwaggerProvider.ProviderTests/Swashbuckle.ResourceControllers.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swashbuckle.ResourceControllers.Tests.fs
@@ -1,30 +1,28 @@
 ﻿module SwashbuckleResourceControllersTests
 
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 open System
 open SwashbuckleReturnControllersTests
 
-type Dict = WebAPI.ResourceStringString
-
 [<Test>]
 let ``ResourceStringString Add and get from resource dictionary`` () =
-    Dict.Put("lang", "F#")
+    api.PutApiResourceStringString("lang", "F#")
 
-    Dict.Get("lang")
-    |> should equal "F#"
+    api.GetApiResourceStringString("lang")
+    |> shouldEqual "F#"
 
 [<Test>]
 let ``ResourceStringString Update value in the resource dictionary`` () =
-    Dict.Put("name", "Sergey")
-    Dict.Get("name")
-    |> should equal "Sergey"
+    api.PutApiResourceStringString("name", "Sergey")
+    api.GetApiResourceStringString("name")
+    |> shouldEqual "Sergey"
 
-    Dict.Post("name", "Siarhei")
-    Dict.Get("name")
-    |> should equal "Siarhei"
+    api.PostApiResourceStringString("name", "Siarhei")
+    api.GetApiResourceStringString("name")
+    |> shouldEqual "Siarhei"
 
 [<Test>]
 let ``ResourceStringString Delete from the dictionary`` () =
-    Dict.Put("url", "http://localhost/")
-    Dict.Delete("url")
+    api.PutApiResourceStringString("url", "http://localhost/")
+    api.DeleteApiResourceStringString("url")

--- a/tests/SwaggerProvider.ProviderTests/Swashbuckle.ReturnControllers.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swashbuckle.ReturnControllers.Tests.fs
@@ -1,152 +1,153 @@
 ﻿module SwashbuckleReturnControllersTests
 
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 open SwaggerProvider
 open System
 
-type WebAPI = SwaggerProvider<"http://localhost:8735/swagger/docs/v1">
+type WebAPI = SwaggerProvider<"http://localhost:8735/swagger/docs/v1", IgnoreOperationId=true>
+let api = WebAPI()
 
 [<Test>]
 let ``Return Bool GET Test`` () =
-    WebAPI.ReturnBoolean.Get()
-    |> should be True
+    api.GetApiReturnBoolean()
+    |> shouldEqual true
 
 [<Test>]
 let ``Return Bool POST Test`` () =
-    WebAPI.ReturnBoolean.Post()
-    |> should be True
+    api.PostApiReturnBoolean()
+    |> shouldEqual true
 
 
 [<Test>]
 let ``Return Int32 GET Test`` () =
-    WebAPI.ReturnInt32.Get()
-    |> should equal 42
+    api.GetApiReturnInt32()
+    |> shouldEqual 42
 
 [<Test>]
 let ``Return Int32 POST Test`` () =
-    WebAPI.ReturnInt32.Post()
-    |> should equal 42
+    api.PostApiReturnInt32()
+    |> shouldEqual 42
 
 
 [<Test>]
 let ``Return Int64 GET Test`` () =
-    WebAPI.ReturnInt64.Get()
-    |> should equal 42L
+    api.GetApiReturnInt64()
+    |> shouldEqual 42L
 
 [<Test>]
 let ``Return Int64 POST Test`` () =
-    WebAPI.ReturnInt64.Post()
-    |> should equal 42L
+    api.PostApiReturnInt64()
+    |> shouldEqual 42L
 
 
 [<Test>]
 let ``Return Float GET Test`` () =
-    WebAPI.ReturnFloat.Get()
-    |> should equal 42.0f
+    api.GetApiReturnFloat()
+    |> shouldEqual 42.0f
 
 [<Test>]
 let ``Return Float POST Test`` () =
-    WebAPI.ReturnFloat.Post()
-    |> should equal 42.0f
+    api.PostApiReturnFloat()
+    |> shouldEqual 42.0f
 
 
 [<Test>]
 let ``Return Double GET Test`` () =
-    WebAPI.ReturnDouble.Get()
-    |> should equal 42.0
+    api.GetApiReturnDouble()
+    |> shouldEqual 42.0
 
 [<Test>]
 let ``Return Double POST Test`` () =
-    WebAPI.ReturnDouble.Post()
-    |> should equal 42.0
+    api.PostApiReturnDouble()
+    |> shouldEqual 42.0
 
 
 [<Test>]
 let ``Return String GET Test`` () =
-    WebAPI.ReturnString.Get()
-    |> should equal "Hello world"
+    api.GetApiReturnString()
+    |> shouldEqual "Hello world"
 
 [<Test>]
 let ``Return String POST Test`` () =
-    WebAPI.ReturnString.Post()
-    |> should equal "Hello world"
+    api.PostApiReturnString()
+    |> shouldEqual "Hello world"
 
 
 [<Test>]
 let ``Return DateTime GET Test`` () =
-    WebAPI.ReturnDateTime.Get()
-    |> should equal (DateTime(2015,1,1))
+    api.GetApiReturnDateTime()
+    |> shouldEqual (DateTime(2015,1,1))
 
 [<Test>]
 let ``Return DateTime POST Test`` () =
-    WebAPI.ReturnDateTime.Post()
-    |> should equal (DateTime(2015,1,1))
+    api.PostApiReturnDateTime()
+    |> shouldEqual (DateTime(2015,1,1))
 
 
 [<Test>]
 let ``Return Enum GET Test`` () =
-    WebAPI.ReturnEnum.Get()
-    |> should equal "1"
+    api.GetApiReturnEnum()
+    |> shouldEqual "1"
 
 [<Test>]
 let ``Return Enum POST Test`` () =
-    WebAPI.ReturnEnum.Post()
-    |> should equal "1"
+    api.PostApiReturnEnum()
+    |> shouldEqual "1"
 
 
 [<Test>]
 let ``Return Array Int GET Test`` () =
-    WebAPI.ReturnArrayInt.Get()
-    |> should equal [|1;2;3|]
+    api.GetApiReturnArrayInt()
+    |> shouldEqual [|1;2;3|]
 
 [<Test>]
 let ``Return Array Int POST Test`` () =
-    WebAPI.ReturnArrayInt.Post()
-    |> should equal [|1;2;3|]
+    api.PostApiReturnArrayInt()
+    |> shouldEqual [|1;2;3|]
 
 
 [<Test>]
 let ``Return Array Enum GET Test`` () =
-    WebAPI.ReturnArrayEnum.Get()
-    |> should equal [|"1";"2"|]
+    api.GetApiReturnArrayEnum()
+    |> shouldEqual [|"1";"2"|]
 
 [<Test>]
 let ``Return Array Enum POST Test`` () =
-    WebAPI.ReturnArrayEnum.Post()
-    |> should equal [|"1";"2"|]
+    api.PostApiReturnArrayEnum()
+    |> shouldEqual [|"1";"2"|]
 
 
 [<Test>]
 let ``Return List Int GET Test`` () =
-    WebAPI.ReturnListInt.Get()
-    |> should equal [|1;2;3|]
+    api.GetApiReturnListInt()
+    |> shouldEqual [|1;2;3|]
 
 [<Test>]
 let ``Return List Int POST Test`` () =
-    WebAPI.ReturnListInt.Post()
-    |> should equal [|1;2;3|]
+    api.PostApiReturnListInt()
+    |> shouldEqual [|1;2;3|]
 
 
 [<Test>]
 let ``Return Seq Int GET Test`` () =
-    WebAPI.ReturnSeqInt.Get()
-    |> should equal [|1;2;3|]
+    api.GetApiReturnSeqInt()
+    |> shouldEqual [|1;2;3|]
 
 [<Test>]
 let ``Return Seq Int POST Test`` () =
-    WebAPI.ReturnSeqInt.Post()
-    |> should equal [|1;2;3|]
+    api.PostApiReturnSeqInt()
+    |> shouldEqual [|1;2;3|]
 
 
 [<Test>]
 let ``Return Object Point GET Test`` () =
-    let point = WebAPI.ReturnObjectPointClass.Get()
-    point.X |> should equal (Some(0))
-    point.Y |> should equal (Some(0))
+    let point = api.GetApiReturnObjectPointClass()
+    point.X |> shouldEqual (Some(0))
+    point.Y |> shouldEqual (Some(0))
 
 [<Test>]
 let ``Return Object Point POST Test`` () =
-    let point = WebAPI.ReturnObjectPointClass.Post()
-    point.X |> should equal (Some(0))
-    point.Y |> should equal (Some(0))
+    let point = api.PostApiReturnObjectPointClass()
+    point.X |> shouldEqual (Some(0))
+    point.Y |> shouldEqual (Some(0))

--- a/tests/SwaggerProvider.ProviderTests/Swashbuckle.UpdateControllers.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swashbuckle.UpdateControllers.Tests.fs
@@ -1,153 +1,153 @@
 ﻿module SwashbuckleUpdateControllersTests
 
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 open System
 open SwashbuckleReturnControllersTests
 
 [<Test>]
 let ``Update Bool GET Test`` () =
-    WebAPI.UpdateBool.Get(true)
-    |> should be False
+    api.GetApiUpdateBool(true)
+    |> shouldEqual false
 
 [<Test>]
 let ``Update Bool POST Test`` () =
-    WebAPI.UpdateBool.Post(false)
-    |> should be True
+    api.PostApiUpdateBool(false)
+    |> shouldEqual true
 
 
 [<Test>]
 let ``Update Int32 GET Test`` () =
-    WebAPI.UpdateInt32.Get(0)
-    |> should equal 1
+    api.GetApiUpdateInt32(0)
+    |> shouldEqual 1
 
 [<Test>]
 let ``Update Int32 POST Test`` () =
-    WebAPI.UpdateInt32.Post(0)
-    |> should equal 1
+    api.PostApiUpdateInt32(0)
+    |> shouldEqual 1
 
 
 [<Test>]
 let ``Update Int64 GET Test`` () =
-    WebAPI.UpdateInt64.Get(10L)
-    |> should equal 11L
+    api.GetApiUpdateInt64(10L)
+    |> shouldEqual 11L
 
 [<Test>]
 let ``Update Int64 POST Test`` () =
-    WebAPI.UpdateInt64.Post(10L)
-    |> should equal 11L
+    api.PostApiUpdateInt64(10L)
+    |> shouldEqual 11L
 
 
 [<Test>]
 let ``Update Float GET Test`` () =
-    WebAPI.UpdateFloat.Get(1.0f)
-    |> should equal 2.0f
+    api.GetApiUpdateFloat(1.0f)
+    |> shouldEqual 2.0f
 
 [<Test>]
 let ``Update Float POST Test`` () =
-    WebAPI.UpdateFloat.Post(1.0f)
-    |> should equal 2.0f
+    api.PostApiUpdateFloat(1.0f)
+    |> shouldEqual 2.0f
 
 
 [<Test>]
 let ``Update Double GET Test`` () =
-    WebAPI.UpdateDouble.Get(2.0)
-    |> should equal 3.0
+    api.GetApiUpdateDouble(2.0)
+    |> shouldEqual 3.0
 
 [<Test>]
 let ``Update Double POST Test`` () =
-    WebAPI.UpdateDouble.Post(2.0)
-    |> should equal 3.0
+    api.PostApiUpdateDouble(2.0)
+    |> shouldEqual 3.0
 
 
 [<Test>]
 let ``Update String GET Test`` () =
-    WebAPI.UpdateString.Get("Serge")
-    |> should equal "Hello, Serge"
+    api.GetApiUpdateString("Serge")
+    |> shouldEqual "Hello, Serge"
 
 [<Test>]
 let ``Update String POST Test`` () =
-    WebAPI.UpdateString.Post("Serge")
-    |> should equal "Hello, Serge"
+    api.PostApiUpdateString("Serge")
+    |> shouldEqual "Hello, Serge"
 
 
 [<Test>]
 let ``Update DateTime GET Test`` () =
-    WebAPI.UpdateDateTime.Get(DateTime(2015,1,1))
-    |> should equal (DateTime(2015,1,2))
+    api.GetApiUpdateDateTime(DateTime(2015,1,1))
+    |> shouldEqual (DateTime(2015,1,2))
 
 [<Test>]
 let ``Update DateTime POST Test`` () =
-    WebAPI.UpdateDateTime.Post(DateTime(2015,1,1))
-    |> should equal (DateTime(2015,1,2))
+    api.PostApiUpdateDateTime(DateTime(2015,1,1))
+    |> shouldEqual (DateTime(2015,1,2))
 
 
 [<Test>]
 let ``Update Enum GET Test`` () =
-    WebAPI.UpdateEnum.Get("1")
-    |> should equal "1"
+    api.GetApiUpdateEnum("1")
+    |> shouldEqual "1"
 
 [<Test>]
 let ``Update Enum POST Test`` () =
-    WebAPI.UpdateEnum.Post("1")
-    |> should equal "1"
+    api.PostApiUpdateEnum("1")
+    |> shouldEqual "1"
 
 
 [<Test>]
 let ``Update Array Int GET Test`` () =
-    WebAPI.UpdateArrayInt.Get([|3;2;1|])
-    |> should equal [|1;2;3|]
+    api.GetApiUpdateArrayInt([|3;2;1|])
+    |> shouldEqual [|1;2;3|]
 
 [<Test>]
 let ``Update Array Int POST Test`` () =
-    WebAPI.UpdateArrayInt.Post([|3;2;1|])
-    |> should equal [|1;2;3|]
+    api.PostApiUpdateArrayInt([|3;2;1|])
+    |> shouldEqual [|1;2;3|]
 
 
 [<Test>]
 let ``Update Array Enum GET Test`` () =
-    WebAPI.UpdateArrayEnum.Get([|"2";"1"|])
-    |> should equal [|"1";"2"|]
+    api.GetApiUpdateArrayEnum([|"2";"1"|])
+    |> shouldEqual [|"1";"2"|]
 
 [<Test>]
 let ``Update Array Enum POST Test`` () =
-    WebAPI.UpdateArrayEnum.Post([|"2";"1"|])
-    |> should equal [|"1";"2"|]
+    api.PostApiUpdateArrayEnum([|"2";"1"|])
+    |> shouldEqual [|"1";"2"|]
 
 
 //[<Test>] // "ExceptionMessage":"No parameterless constructor defined for this object."
 //let ``Update List Int GET Test`` () =
 //    WebAPI.UpdateListInt.Get([|3;2;1|])
-//    |> should equal [|1;2;3|]
+//    |> shouldEqual [|1;2;3|]
 
 [<Test>]
 let ``Update List Int POST Test`` () =
-    WebAPI.UpdateListInt.Post([|3;2;1|])
-    |> should equal [|1;2;3|]
+    api.PostApiUpdateListInt([|3;2;1|])
+    |> shouldEqual [|1;2;3|]
 
 
 [<Test>]
 let ``Update Seq Int GET Test`` () =
-    WebAPI.UpdateSeqInt.Get([|3;2;1|])
-    |> should equal [|1;2;3|]
+    api.GetApiUpdateSeqInt([|3;2;1|])
+    |> shouldEqual [|1;2;3|]
 
 [<Test>]
 let ``Update Seq Int POST Test`` () =
-    WebAPI.UpdateSeqInt.Post([|3;2;1|])
-    |> should equal [|1;2;3|]
+    api.PostApiUpdateSeqInt([|3;2;1|])
+    |> shouldEqual [|1;2;3|]
 
 
 [<Test>]
 let ``Update Object Point GET Test`` () =
-    let point = WebAPI.UpdateObjectPointClass.Get(xX = Some 1, xY = Some 2)
-    point.X |> should equal (Some 2)
-    point.Y |> should equal (Some 1)
+    let point = api.GetApiUpdateObjectPointClass(xX = Some 1, xY = Some 2)
+    point.X |> shouldEqual (Some 2)
+    point.Y |> shouldEqual (Some 1)
 
 [<Test>]
 let ``Update Object Point POST Test`` () =
-    let p = WebAPI.Definitions.PointClass()
+    let p = WebAPI.PointClass()
     p.X <- Some 1
     p.Y <- Some 2
-    let point = WebAPI.UpdateObjectPointClass.Post(p)
-    point.X |> should equal (Some 2)
-    point.Y |> should equal (Some 1)
+    let point = api.PostApiUpdateObjectPointClass(p)
+    point.X |> shouldEqual (Some 2)
+    point.Y |> shouldEqual (Some 1)

--- a/tests/SwaggerProvider.ProviderTests/paket.references
+++ b/tests/SwaggerProvider.ProviderTests/paket.references
@@ -1,3 +1,3 @@
 group Test
     NUnit
-    File:FsUnit.fs
+    File:FsUnitTyped.fs

--- a/tests/SwaggerProvider.Tests/Schema.DefinitionsTests.fs
+++ b/tests/SwaggerProvider.Tests/Schema.DefinitionsTests.fs
@@ -4,14 +4,14 @@ open SwaggerProvider.Internal.Schema
 open SwaggerProvider.Internal.Schema.Parsers
 open FSharp.Data
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 
 let shouldBeEqual (expected:SchemaObject) content =
     content
     |> JsonValue.Parse
     |> JsonNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal expected
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual expected
 
 [<Test>]
 let ``parse boolean`` () =

--- a/tests/SwaggerProvider.Tests/Schema.Parser.Tests.fs
+++ b/tests/SwaggerProvider.Tests/Schema.Parser.Tests.fs
@@ -5,7 +5,7 @@ open SwaggerProvider.Internal.Schema.Parsers
 open SwaggerProvider.Internal.Compilers
 open FSharp.Data
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 open System.IO
 
 [<SetUpFixture>]
@@ -24,10 +24,10 @@ let ``Schema parse of PetStore.Swagger.json sample`` () =
         |> JsonValue.Parse
         |> JsonNodeAdapter
         |> Parser.parseSwaggerObject
-    schema.Definitions |> should haveLength 6
+    schema.Definitions |> shouldHaveLength 6
 
     schema.Info
-    |> should equal {
+    |> shouldEqual {
         Title = "Swagger Petstore"
         Version = "1.0.0"
         Description = "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters."
@@ -41,7 +41,7 @@ let ``Schema parse of PetStore.Swagger.json sample (online)`` () =
         |> JsonValue.Parse
         |> JsonNodeAdapter
         |> Parser.parseSwaggerObject
-    schema.Definitions |> should haveLength 6
+    schema.Definitions |> shouldHaveLength 6
 
     let schemaOnline =
         "http://petstore.swagger.io/v2/swagger.json"
@@ -50,14 +50,14 @@ let ``Schema parse of PetStore.Swagger.json sample (online)`` () =
         |> JsonNodeAdapter
         |> Parser.parseSwaggerObject
 
-    schemaOnline.BasePath |> should equal schema.BasePath
-    schemaOnline.Host |> should equal schema.Host
-    schemaOnline.Info |> should equal schema.Info
-    schemaOnline.Schemes |> should equal schema.Schemes
-    schemaOnline.Tags |> should equal schema.Tags
-    schemaOnline.Definitions |> should equal schema.Definitions
-    schemaOnline.Paths |> should equal schema.Paths
-    schemaOnline |> should equal schema
+    schemaOnline.BasePath |> shouldEqual schema.BasePath
+    schemaOnline.Host |> shouldEqual schema.Host
+    schemaOnline.Info |> shouldEqual schema.Info
+    schemaOnline.Schemes |> shouldEqual schema.Schemes
+    schemaOnline.Tags |> shouldEqual schema.Tags
+    schemaOnline.Definitions |> shouldEqual schema.Definitions
+    schemaOnline.Paths |> shouldEqual schema.Paths
+    schemaOnline |> shouldEqual schema
 
 
 // Test that provider can parse real-word Swagger 2.0 schemas
@@ -114,13 +114,13 @@ let parserTestBody formatParser (url:string) =
         let schema = formatParser schemaStr
                      |> Parsers.Parser.parseSwaggerObject
 
-        schema.Paths.Length + schema.Definitions.Length |> should be (greaterThan 0)
+        schema.Paths.Length + schema.Definitions.Length |> shouldBeGreaterThan 0
 
         //Number of generated types may be less than number of type definition in schema
         //TODO: Check if TPs are able to generate aliases like `type RandomInd = int`
         let defCompiler = DefinitionCompiler(schema)
         let opCompiler = OperationCompiler(schema, defCompiler)
-        ignore <| opCompiler.CompilePaths()
+        ignore <| opCompiler.CompilePaths(false)
         ignore <| defCompiler.GetProvidedTypes()
 
 

--- a/tests/SwaggerProvider.Tests/Schema.Parser.Tests.fs
+++ b/tests/SwaggerProvider.Tests/Schema.Parser.Tests.fs
@@ -99,12 +99,6 @@ let IgnoreList =
      "https://apis-guru.github.io/api-models/sendgrid.com/3.0/swagger.yaml"
     ] |> Set.ofList
 
-let SchemasWithZeroPathes =
-    [
-     "https://apis-guru.github.io/api-models/googleapis.com/iam/v1alpha1/swagger.json"
-     "https://apis-guru.github.io/api-models/googleapis.com/iam/v1alpha1/swagger.yaml"
-    ] |> Set.ofList
-
 let parserTestBody formatParser (url:string) =
     let schemaStr =
         try
@@ -120,15 +114,13 @@ let parserTestBody formatParser (url:string) =
         let schema = formatParser schemaStr
                      |> Parsers.Parser.parseSwaggerObject
 
-        if Set.contains url SchemasWithZeroPathes
-        then schema.Paths.Length |> should equal 0
-        else schema.Paths.Length + schema.Definitions.Length |> should be (greaterThan 0)
+        schema.Paths.Length + schema.Definitions.Length |> should be (greaterThan 0)
 
         //Number of generated types may be less than number of type definition in schema
         //TODO: Check if TPs are able to generate aliases like `type RandomInd = int`
         let defCompiler = DefinitionCompiler(schema)
-        let opCompiler = OperationCompiler(schema, defCompiler, [])
-        ignore <| opCompiler.Compile(url)
+        let opCompiler = OperationCompiler(schema, defCompiler)
+        ignore <| opCompiler.CompilePaths()
         ignore <| defCompiler.GetProvidedTypes()
 
 

--- a/tests/SwaggerProvider.Tests/Schema.PathsTests.fs
+++ b/tests/SwaggerProvider.Tests/Schema.PathsTests.fs
@@ -4,14 +4,14 @@ open SwaggerProvider.Internal.Schema
 open SwaggerProvider.Internal.Schema.Parsers
 open FSharp.Data
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 
 let shouldBeEqualToTag (expected:TagObject) content =
     content
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseTagObject
-    |> should equal expected
+    |> shouldEqual expected
 
 [<Test>]
 let ``parse simple tag`` () =

--- a/tests/SwaggerProvider.Tests/Schema.Spec.Json.Tests.fs
+++ b/tests/SwaggerProvider.Tests/Schema.Spec.Json.Tests.fs
@@ -3,7 +3,7 @@
 open SwaggerProvider.Internal.Schema
 open SwaggerProvider.Internal.Schema.Parsers
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 open FSharp.Data
 
 [<Test>]
@@ -26,7 +26,7 @@ let ``Info Object Example`` () =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseInfoObject
-    |> should equal
+    |> shouldEqual
         {
             Title = "Swagger Sample App"
             Description = "This is a sample server Petstore server."
@@ -60,7 +60,7 @@ let ``Paths Object Example`` () =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parsePathsObject Parser.ParserContext.Empty
-    |> should equal
+    |> shouldEqual
         [|{
             Path = "/pets"
             Type = Get
@@ -125,7 +125,7 @@ let ``Path Item Object Example`` () =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parsePathsObject Parser.ParserContext.Empty
-    |> should equal
+    |> shouldEqual
         [|{
             Path = "/pets"
             Type = Get
@@ -214,7 +214,7 @@ let ``Operation Object Example`` () =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseOperationObject Parser.ParserContext.Empty "/" Get
-    |> should equal
+    |> shouldEqual
         {
             Path = "/"
             Type = Get
@@ -274,7 +274,7 @@ let ``Parameter Object Examples: Body Parameters``() =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseParameterObject
-    |> should equal
+    |> shouldEqual
         {
             Name = "user"
             In = Body
@@ -302,7 +302,7 @@ let ``Parameter Object Examples: Body Parameters Array``() =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseParameterObject
-    |> should equal
+    |> shouldEqual
         {
             Name = "user"
             In = Body
@@ -330,7 +330,7 @@ let ``Parameter Object Examples: Other Parameters``() =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseParameterObject
-    |> should equal
+    |> shouldEqual
         {
             Name = "token"
             In = Header
@@ -353,7 +353,7 @@ let ``Parameter Object Examples: Other Parameters - Path String``() =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseParameterObject
-    |> should equal
+    |> shouldEqual
         {
             Name = "username"
             In = Path
@@ -380,7 +380,7 @@ let ``Parameter Object Examples: Other Parameters - Array String Multi``() =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseParameterObject
-    |> should equal
+    |> shouldEqual
         {
             Name = "id"
             In = Query
@@ -403,7 +403,7 @@ let ``Parameter Object Examples: Other Parameters - File``() =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseParameterObject
-    |> should equal
+    |> shouldEqual
         {
             Name = "avatar"
             In = FormData
@@ -428,7 +428,7 @@ let ``Response Object Examples: Response of an array of a complex type`` () =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseResponseObject (Parser.ParserContext.Empty)
-    |> should equal
+    |> shouldEqual
         {
             Description = "A complex object array response"
             Schema = Some <| Array (Reference "#/definitions/VeryComplexType")
@@ -447,7 +447,7 @@ let ``Response Object Examples: Response with a string type`` () =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseResponseObject (Parser.ParserContext.Empty)
-    |> should equal
+    |> shouldEqual
         {
             Description = "A simple string response"
             Schema = Some String
@@ -479,7 +479,7 @@ let ``Response Object Examples: Response with headers`` () =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseResponseObject (Parser.ParserContext.Empty)
-    |> should equal
+    |> shouldEqual
         {
             Description = "A simple string response"
             Schema = Some String
@@ -494,7 +494,7 @@ let ``Response Object Examples: Response with no return value`` () =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseResponseObject (Parser.ParserContext.Empty)
-    |> should equal
+    |> shouldEqual
         {
             Description = "object created"
             Schema = None
@@ -511,7 +511,7 @@ let ``Tag Object Example`` () =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseTagObject
-    |> should equal
+    |> shouldEqual
         ({
             Name = "pet"
             Description = "Pets operations"
@@ -525,8 +525,8 @@ let ``Reference Object Example`` () =
     }"""
     |> JsonValue.Parse
     |> JsonNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         (Reference "#/definitions/Pet")
 
 
@@ -538,8 +538,8 @@ let ``Schema Object Examples: Primitive Sample`` () =
     }"""
     |> JsonValue.Parse
     |> JsonNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         String
 
 
@@ -566,8 +566,8 @@ let ``Schema Object Examples: Simple Model`` () =
     }"""
     |> JsonValue.Parse
     |> JsonNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         (Object
             [|{Name = "name"
                Type = String
@@ -594,8 +594,8 @@ let ``Schema Object Examples: Model with Map/Dictionary Properties: For a simple
     }"""
     |> JsonValue.Parse
     |> JsonNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         (Dictionary String)
 
 
@@ -609,8 +609,8 @@ let ``Schema Object Examples: Model with Map/Dictionary Properties: For a string
     }"""
     |> JsonValue.Parse
     |> JsonNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         (Dictionary (Reference "#/definitions/ComplexModel"))
 
 
@@ -637,8 +637,8 @@ let ``Schema Object Examples: Model with Example`` () =
     }"""
     |> JsonValue.Parse
     |> JsonNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         (Object
             [|{Name = "id"
                Type = Int64
@@ -693,7 +693,9 @@ let ``Schema Object Examples: Models with Composition`` () =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseDefinitionsObject
-    |> should equal
+    |> Seq.map (fun x -> x.Key, x.Value.Value)
+    |> Map.ofSeq
+    |> shouldEqual
        ([|
             "#/definitions/ErrorModel",
             (Object
@@ -796,8 +798,8 @@ let ``Schema Object Examples: Models with Polymorphism Support`` () =
     }"""
     |> JsonValue.Parse
     |> JsonNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         (Object
             [||]
         )
@@ -834,7 +836,9 @@ let ``Definitions Object Example`` () =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseDefinitionsObject
-    |> should equal
+    |> Seq.map (fun x->x.Key, x.Value.Value)
+    |> Map.ofSeq
+    |> shouldEqual
        ([|
             "#/definitions/Category",
             (Object
@@ -884,7 +888,7 @@ let ``Parameters Definition Object Example`` () =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseParametersDefinition
-    |> should equal
+    |> shouldEqual
         ([|
             "#/parameters/skipParam",
             {
@@ -925,7 +929,7 @@ let ``Responses Definitions Object Example`` () =
     |> JsonValue.Parse
     |> JsonNodeAdapter
     |> Parser.parseResponsesDefinition
-    |> should equal
+    |> shouldEqual
         ([|
             "#/responses/NotFound",
             {

--- a/tests/SwaggerProvider.Tests/Schema.Spec.Yaml.Tests.fs
+++ b/tests/SwaggerProvider.Tests/Schema.Spec.Yaml.Tests.fs
@@ -4,7 +4,7 @@ open SwaggerProvider
 open SwaggerProvider.Internal.Schema
 open SwaggerProvider.Internal.Schema.Parsers
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 
 [<Test>]
 let ``Info Object Example`` () =
@@ -24,7 +24,7 @@ version: 1.0.1
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseInfoObject
-    |> should equal
+    |> shouldEqual
         {
             Title = "Swagger Sample App"
             Description = "This is a sample server Petstore server."
@@ -51,7 +51,7 @@ let ``Paths Object Example`` () =
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parsePathsObject Parser.ParserContext.Empty
-    |> should equal
+    |> shouldEqual
         [|{
             Path = "/pets"
             Type = Get
@@ -105,7 +105,7 @@ let ``Path Item Object Example`` () =
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parsePathsObject Parser.ParserContext.Empty
-    |> should equal
+    |> shouldEqual
         [|{
             Path = "/pets"
             Type = Get
@@ -176,7 +176,7 @@ security:
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseOperationObject Parser.ParserContext.Empty "/" Get
-    |> should equal
+    |> shouldEqual
         {
             Path = "/"
             Type = Get
@@ -235,7 +235,7 @@ schema:
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseParameterObject
-    |> should equal
+    |> shouldEqual
         {
             Name = "user"
             In = Body
@@ -261,7 +261,7 @@ schema:
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseParameterObject
-    |> should equal
+    |> shouldEqual
         {
             Name = "user"
             In = Body
@@ -288,7 +288,7 @@ collectionFormat: csv
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseParameterObject
-    |> should equal
+    |> shouldEqual
         {
             Name = "token"
             In = Header
@@ -311,7 +311,7 @@ type: string
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseParameterObject
-    |> should equal
+    |> shouldEqual
         {
             Name = "username"
             In = Path
@@ -337,7 +337,7 @@ collectionFormat: multi
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseParameterObject
-    |> should equal
+    |> shouldEqual
         {
             Name = "id"
             In = Query
@@ -360,7 +360,7 @@ type: file
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseParameterObject
-    |> should equal
+    |> shouldEqual
         {
             Name = "avatar"
             In = FormData
@@ -383,7 +383,7 @@ schema:
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseResponseObject (Parser.ParserContext.Empty)
-    |> should equal
+    |> shouldEqual
         {
             Description = "A complex object array response"
             Schema = Some <| Array (Reference "#/definitions/VeryComplexType")
@@ -401,7 +401,7 @@ schema:
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseResponseObject (Parser.ParserContext.Empty)
-    |> should equal
+    |> shouldEqual
         {
             Description = "A simple string response"
             Schema = Some String
@@ -428,7 +428,7 @@ headers:
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseResponseObject (Parser.ParserContext.Empty)
-    |> should equal
+    |> shouldEqual
         {
             Description = "A simple string response"
             Schema = Some String
@@ -443,7 +443,7 @@ description: object created
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseResponseObject (Parser.ParserContext.Empty)
-    |> should equal
+    |> shouldEqual
         {
             Description = "object created"
             Schema = None
@@ -460,7 +460,7 @@ description: Pets operations
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseTagObject
-    |> should equal
+    |> shouldEqual
         ({
             Name = "pet"
             Description = "Pets operations"
@@ -474,8 +474,8 @@ $ref: '#/definitions/Pet'
 """
     |> YamlParser.Parse
     |> YamlNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         (Reference "#/definitions/Pet")
 
 
@@ -487,8 +487,8 @@ format: email
 """
     |> YamlParser.Parse
     |> YamlNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         String
 
 
@@ -510,8 +510,8 @@ properties:
 """
     |> YamlParser.Parse
     |> YamlNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         (Object
             [|{Name = "name"
                Type = String
@@ -537,8 +537,8 @@ additionalProperties:
 """
     |> YamlParser.Parse
     |> YamlNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         (Dictionary String)
 
 
@@ -551,8 +551,8 @@ additionalProperties:
 """
     |> YamlParser.Parse
     |> YamlNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         (Dictionary (Reference "#/definitions/ComplexModel"))
 
 
@@ -574,8 +574,8 @@ example:
 """
     |> YamlParser.Parse
     |> YamlNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         (Object
             [|{Name = "id"
                Type = Int64
@@ -616,7 +616,9 @@ ExtendedErrorModel:
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseDefinitionsObject
-    |> should equal
+    |> Seq.map (fun x->x.Key, x.Value.Value)
+    |> Map.ofSeq
+    |> shouldEqual
        ([|
             "#/definitions/ErrorModel",
             (Object
@@ -694,8 +696,8 @@ definitions:
 """
     |> YamlParser.Parse
     |> YamlNodeAdapter
-    |> Parser.parseSchemaObject Map.empty
-    |> should equal
+    |> Parser.parseSchemaObject Parser.emptyDict
+    |> shouldEqual
         (Object
             [||]
         )
@@ -724,7 +726,9 @@ Tag:
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseDefinitionsObject
-    |> should equal
+    |> Seq.map (fun x->x.Key, x.Value.Value)
+    |> Map.ofSeq
+    |> shouldEqual
        ([|
             "#/definitions/Category",
             (Object
@@ -772,7 +776,7 @@ limitParam:
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseParametersDefinition
-    |> should equal
+    |> shouldEqual
         ([|
             "#/parameters/skipParam",
             {
@@ -809,7 +813,7 @@ GeneralError:
     |> YamlParser.Parse
     |> YamlNodeAdapter
     |> Parser.parseResponsesDefinition
-    |> should equal
+    |> shouldEqual
         ([|
             "#/responses/NotFound",
             {

--- a/tests/SwaggerProvider.Tests/Schemas/PetStore.Swagger.json
+++ b/tests/SwaggerProvider.Tests/Schemas/PetStore.Swagger.json
@@ -573,7 +573,7 @@
     "securityDefinitions": {
         "petstore_auth": {
             "type": "oauth2",
-            "authorizationUrl": "http://petstore.swagger.io/api/oauth/dialog",
+            "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
             "flow": "implicit",
             "scopes": {
                 "write:pets": "modify pets in your account",
@@ -618,17 +618,6 @@
             },
             "xml": { "name": "Order" }
         },
-        "Category": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "name": { "type": "string" }
-            },
-            "xml": { "name": "Category" }
-        },
         "User": {
             "type": "object",
             "properties": {
@@ -650,6 +639,17 @@
             },
             "xml": { "name": "User" }
         },
+        "Category": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": { "type": "string" }
+            },
+            "xml": { "name": "Category" }
+        },
         "Tag": {
             "type": "object",
             "properties": {
@@ -660,17 +660,6 @@
                 "name": { "type": "string" }
             },
             "xml": { "name": "Tag" }
-        },
-        "ApiResponse": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "integer",
-                    "format": "int32"
-                },
-                "type": { "type": "string" },
-                "message": { "type": "string" }
-            }
         },
         "Pet": {
             "type": "object",
@@ -708,6 +697,17 @@
                 }
             },
             "xml": { "name": "Pet" }
+        },
+        "ApiResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "type": { "type": "string" },
+                "message": { "type": "string" }
+            }
         }
     },
     "externalDocs": {

--- a/tests/SwaggerProvider.Tests/SwaggerProvider.Tests.fsproj
+++ b/tests/SwaggerProvider.Tests/SwaggerProvider.Tests.fsproj
@@ -65,9 +65,9 @@
   -->
   <Import Project="..\..\.paket\paket.targets" />
   <ItemGroup>
-    <Compile Include="..\..\paket-files\test\fsprojects\FsUnit\src\FsUnit.NUnit\FsUnit.fs">
+    <Compile Include="..\..\paket-files\test\fsprojects\FsUnit\src\FsUnit.NUnit\FsUnitTyped.fs">
       <Paket>True</Paket>
-      <Link>paket-files/FsUnit.fs</Link>
+      <Link>paket-files/FsUnitTyped.fs</Link>
     </Compile>
     <None Include="Schemas\PetStore.Swagger.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/tests/SwaggerProvider.Tests/paket.references
+++ b/tests/SwaggerProvider.Tests/paket.references
@@ -1,4 +1,4 @@
 group Test
     NUnit
     FSharp.Data
-    File:FsUnit.fs
+    File:FsUnitTyped.fs


### PR DESCRIPTION
- [x] Instance methods for provided operations with configurable Host, Headers and modifiable web requests
- [x] Configurable operation name (`IgnoreOperationId` parameter)
- [x] Support of unordered type definitions in schema (for Azure API)
- [x] Migration to [FsUnitTyped](http://fsprojects.github.io/FsUnit/FsUnitTyped.html) + better testing
- [x] Contains fix for #22 