### PR TITLE
corrected web links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SwaggerProvider [![NuGet Badge](https://buildstats.info/nuget/SwaggerProvider)](https://www.nuget.org/packages/SwaggerProvider)
 
-[![Join the chat at https://gitter.im/sergey-tihon/SwaggerProvider](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sergey-tihon/SwaggerProvider?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/fsprojects/SwaggerProvider](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/fsprojects/SwaggerProvider?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This SwaggerProvider can be used to access RESTful API generated using [Swagger.io](http://swagger.io)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,7 +18,7 @@
 * Added support of composite types like ("type": [ "string", "null" ])
 
 #### 0.3.5 - February 25 2016
-* Added ability to override Host property at runtime - https://github.com/sergey-tihon/SwaggerProvider/issues/15
+* Added ability to override Host property at runtime - https://github.com/fsprojects/SwaggerProvider/issues/15
 
 #### 0.3.4 - January 20 2016
 * Fixed generation of obsolete provided methods - https://github.com/fsprojects/FSharp.TypeProviders.StarterPack/issues/70

--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -6,7 +6,7 @@
 // Web site location for the generated documentation
 let website = "/SwaggerProvider"
 
-let githubLink = "https://github.com/sergey-tihon/SwaggerProvider"
+let githubLink = "https://github.com/fsprojects/SwaggerProvider"
 
 // Specify more information about your project
 let info =

--- a/src/SwaggerProvider.DesignTime/SchemaParser.fs
+++ b/src/SwaggerProvider.DesignTime/SchemaParser.fs
@@ -150,7 +150,7 @@ module Parser =
                 (fun obj -> // Models with Polymorphism Support
                     match obj.TryGetProperty("discriminator") with
                     | Some(discriminator) ->
-                        failwith "Models with Polymorphism Support is not supported yet. If you see this error plrease report it on GitHub (https://github.com/sergey-tihon/SwaggerProvider/issues) with schema example."
+                        failwith "Models with Polymorphism Support is not supported yet. If you see this error plrease report it on GitHub (https://github.com/fsprojects/SwaggerProvider/issues) with schema example."
                     | None -> None
                 )
             |]

--- a/src/SwaggerProvider/paket.template
+++ b/src/SwaggerProvider/paket.template
@@ -4,11 +4,11 @@ owners
 authors
     Sergey Tihon
 projectUrl
-    http://sergey-tihon.github.io/SwaggerProvider/
+    http://fsprojects.github.io/SwaggerProvider/
 iconUrl
-    https://raw.githubusercontent.com/sergey-tihon/SwaggerProvider/master/docs/files/img/logo.png
+    https://raw.githubusercontent.com/fsprojects/SwaggerProvider/master/docs/files/img/logo.png
 licenseUrl
-    http://github.com/sergey-tihon/SwaggerProvider/blob/master/LICENSE.txt
+    http://github.com/fsprojects/SwaggerProvider/blob/master/LICENSE.txt
 requireLicenseAcceptance
     false
 copyright


### PR DESCRIPTION
Click on [NuGet Page](https://www.nuget.org/packages/SwaggerProvider) to "Project Site" leads to [404 site] (http://sergey-tihon.github.io/SwaggerProvider/)
Fixed it to http://fsprojects.github.io/SwaggerProvider/ and corrected a pair of other occurences

The appveyor build project is still on https://ci.appveyor.com/project/sergey-tihon/swaggerprovider