### PR TITLE
Migrate APIs.guru related URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This SwaggerProvider can be used to access RESTful API generated using [Swagger.
 
 [![Travis build status](https://travis-ci.org/fsprojects/SwaggerProvider.svg)](https://travis-ci.org/fsprojects/SwaggerProvider)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/tcahkn4b1tayh39u?svg=true)](https://ci.appveyor.com/project/sergey-tihon/swaggerprovider)
-[![Tested on APIs.guru](http://apis-guru.github.io/api-models/banners/tested_on_banner.svg)](https://github.com/APIs-guru/api-models)
+[![Tested on APIs.guru](https://api.apis.guru/badges/tested_on.svg)](https://APIs.guru)
 
 Documentation:  http://fsprojects.github.io/SwaggerProvider/ 
 

--- a/tests/SwaggerProvider.Tests/Schema.Parser.Tests.fs
+++ b/tests/SwaggerProvider.Tests/Schema.Parser.Tests.fs
@@ -62,7 +62,7 @@ let ``Schema parse of PetStore.Swagger.json sample (online)`` () =
 
 // Test that provider can parse real-word Swagger 2.0 schemas
 // https://github.com/APIs-guru/api-models/blob/master/API.md
-type ApisGuru = FSharp.Data.JsonProvider<"http://apis-guru.github.io/api-models/api/v1/list.json">
+type ApisGuru = FSharp.Data.JsonProvider<"https://api.apis.guru/v2/list.json">
 
 let toTestCase (url:string) =
     TestCaseData(url).SetName(sprintf "Parse schema %s" url)
@@ -100,8 +100,8 @@ let SchemaUrls =
 
 let IgnoreList =
     [
-     "https://apis-guru.github.io/api-models/sendgrid.com/3.0/swagger.json"
-     "https://apis-guru.github.io/api-models/sendgrid.com/3.0/swagger.yaml"
+     "https://api.apis.guru/v2/specs/sendgrid.com/3.0/swagger.json"
+     "https://api.apis.guru/v2/specs/sendgrid.com/3.0/swagger.yaml"
     ] |> Set.ofList
 
 let parserTestBody formatParser (url:string) =


### PR DESCRIPTION
Hi @sergey-tihon 

We are migrating our URLs to `APIs.guru` domain, here is more details:
https://github.com/APIs-guru/api-models/issues/85