### PR TITLE
add file upload and download endpoints to the test controller

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -7,7 +7,7 @@ nuget FSharp.Core ~> 4.0.0
 nuget YamlDotNet
 
 github fsharp/FSharp.Data src/Net/UriUtils.fs
-github baronfel/FSharp.Data:multipart_form_data src/Net/Http.fs
+github fsharp/FSharp.Data src/Net/Http.fs
 github fsharp/FSharp.Data src/CommonRuntime/IO.fs
 github fsharp/FSharp.Data src/CommonRuntime/TextConversions.fs
 github fsharp/FSharp.Data src/CommonRuntime/Pluralizer.fs

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,5 +1,6 @@
 source https://nuget.org/api/v2
 framework: >= net45
+redirects: on
 
 nuget Newtonsoft.Json >= 9.0.1
 nuget FSharp.Core ~> 4.0.0

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,7 +6,7 @@ nuget FSharp.Core ~> 4.0.0
 nuget YamlDotNet
 
 github fsharp/FSharp.Data src/Net/UriUtils.fs
-github fsharp/FSharp.Data src/Net/Http.fs
+github baronfel/FSharp.Data:multipart_form_data src/Net/Http.fs
 github fsharp/FSharp.Data src/CommonRuntime/IO.fs
 github fsharp/FSharp.Data src/CommonRuntime/TextConversions.fs
 github fsharp/FSharp.Data src/CommonRuntime/Pluralizer.fs

--- a/paket.lock
+++ b/paket.lock
@@ -1,5 +1,5 @@
 REDIRECTS: ON
-FRAMEWORK: >= NET45
+RESTRICTION: >= net45
 NUGET
   remote: https://www.nuget.org/api/v2
     FSharp.Core (4.0.0.1)

--- a/paket.lock
+++ b/paket.lock
@@ -1,4 +1,5 @@
-RESTRICTION: >= net45
+REDIRECTS: ON
+FRAMEWORK: >= NET45
 NUGET
   remote: https://www.nuget.org/api/v2
     FSharp.Core (4.0.0.1)

--- a/paket.lock
+++ b/paket.lock
@@ -14,8 +14,9 @@ GITHUB
     src/Json/JsonConversions.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
     src/Json/JsonExtensions.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
     src/Json/JsonValue.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
-    src/Net/Http.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
     src/Net/UriUtils.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
+  remote: baronfel/FSharp.Data
+    src/Net/Http.fs (1cb6137d5cc10a0c633858b2e0dbc340c5ed4736)
   remote: fsprojects/FSharp.TypeProviders.StarterPack
     src/ProvidedTypes.fs (1dab4f94411500794342f61f877feab772e5a754)
     src/ProvidedTypes.fsi (1dab4f94411500794342f61f877feab772e5a754)

--- a/paket.lock
+++ b/paket.lock
@@ -7,21 +7,20 @@ NUGET
     YamlDotNet (4.2.1)
 GITHUB
   remote: fsharp/FSharp.Data
-    src/CommonRuntime/IO.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
-    src/CommonRuntime/NameUtils.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
-    src/CommonRuntime/Pluralizer.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
-    src/CommonRuntime/StructuralTypes.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
-    src/CommonRuntime/TextConversions.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
-    src/Json/JsonConversions.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
-    src/Json/JsonExtensions.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
-    src/Json/JsonValue.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
-    src/Net/UriUtils.fs (503ed03c0ab56dcd4938946d898df886a7c5a79c)
-  remote: baronfel/FSharp.Data
-    src/Net/Http.fs (1cb6137d5cc10a0c633858b2e0dbc340c5ed4736)
+    src/CommonRuntime/IO.fs (4c99395411e923afc82d010fd89190dd43c60a79)
+    src/CommonRuntime/NameUtils.fs (4c99395411e923afc82d010fd89190dd43c60a79)
+    src/CommonRuntime/Pluralizer.fs (4c99395411e923afc82d010fd89190dd43c60a79)
+    src/CommonRuntime/StructuralTypes.fs (4c99395411e923afc82d010fd89190dd43c60a79)
+    src/CommonRuntime/TextConversions.fs (4c99395411e923afc82d010fd89190dd43c60a79)
+    src/Json/JsonConversions.fs (4c99395411e923afc82d010fd89190dd43c60a79)
+    src/Json/JsonExtensions.fs (4c99395411e923afc82d010fd89190dd43c60a79)
+    src/Json/JsonValue.fs (4c99395411e923afc82d010fd89190dd43c60a79)
+    src/Net/Http.fs (4c99395411e923afc82d010fd89190dd43c60a79)
+    src/Net/UriUtils.fs (4c99395411e923afc82d010fd89190dd43c60a79)
   remote: fsprojects/FSharp.TypeProviders.StarterPack
-    src/ProvidedTypes.fs (1dab4f94411500794342f61f877feab772e5a754)
-    src/ProvidedTypes.fsi (1dab4f94411500794342f61f877feab772e5a754)
-    src/ProvidedTypesTesting.fs (1dab4f94411500794342f61f877feab772e5a754)
+    src/ProvidedTypes.fs (c372debaa7ef4febfe16d98dec765d74640bbe82)
+    src/ProvidedTypes.fsi (c372debaa7ef4febfe16d98dec765d74640bbe82)
+    src/ProvidedTypesTesting.fs (c372debaa7ef4febfe16d98dec765d74640bbe82)
 GROUP Build
 RESTRICTION: == net45
 NUGET

--- a/src/SwaggerProvider.DesignTime/DefinitionCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/DefinitionCompiler.fs
@@ -66,7 +66,7 @@ type DefinitionCompiler (schema:SwaggerObject) =
         | String, _       -> typeof<string>
         | Date, true  | DateTime, true   -> typeof<DateTime>
         | Date, false | DateTime, false  -> typeof<Option<DateTime>>
-        | File, _         -> typeof<byte>.MakeArrayType(1)
+        | File, _         -> typeof<Tuple<string, IO.Stream>>
         | Enum _, _       -> typeof<string> //TODO: find better type
         | Array eTy, _    -> (compileSchemaObject (uniqueName tyName "Item") eTy true).MakeArrayType()
         | Dictionary eTy,_-> typedefof<Map<string, obj>>.MakeGenericType(
@@ -155,8 +155,7 @@ type DefinitionCompiler (schema:SwaggerObject) =
 
     // Compiles the `definitions` part of the schema
     do  schema.Definitions
-        |> Seq.iter (fun (name,_) ->
-            compileDefinition name |> ignore)
+        |> Seq.iter (fst >> compileDefinition >> ignore)
 
     /// Compiles the definition.
     member __.GetProvidedTypes() =

--- a/src/SwaggerProvider.DesignTime/DefinitionCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/DefinitionCompiler.fs
@@ -8,6 +8,10 @@ open Microsoft.FSharp.Quotations
 open System
 open System.Reflection
 
+type FileWrapper(fileName: string, data: IO.Stream) =
+    member __.fileName = fileName
+    member __.data = data
+
 /// Object for compiling definitions.
 type DefinitionCompiler (schema:SwaggerObject) =
     let definitions = Map.ofSeq schema.Definitions
@@ -66,7 +70,7 @@ type DefinitionCompiler (schema:SwaggerObject) =
         | String, _       -> typeof<string>
         | Date, true  | DateTime, true   -> typeof<DateTime>
         | Date, false | DateTime, false  -> typeof<Option<DateTime>>
-        | File, _         -> typeof<Tuple<string, IO.Stream>>
+        | File, _         -> typeof<FileWrapper> // contentType * fileStream
         | Enum _, _       -> typeof<string> //TODO: find better type
         | Array eTy, _    -> (compileSchemaObject (uniqueName tyName "Item") eTy true).MakeArrayType()
         | Dictionary eTy,_-> typedefof<Map<string, obj>>.MakeGenericType(

--- a/src/SwaggerProvider.DesignTime/OperationCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/OperationCompiler.fs
@@ -162,9 +162,7 @@ type OperationCompiler (schema:SwaggerObject, defCompiler:DefinitionCompiler) =
                         let value = coerceString param.Type param.CollectionFormat exp
                         match param.In with
                         | Path   -> (replacePathTemplate path name value, load, quer, head)
-                        // swagger doesn't support file in the body, so formdata is the only time we have to check on send
-                        | FormData -> (path, addPayload load param exp, quer, head)
-                        | Body   -> (path, addPayload load param exp, quer, head) 
+                        | FormData | Body -> (path, addPayload load param exp, quer, head)
                         | Query  -> (path, load, addQuery quer name exp, head)
                         | Header -> (path, load, quer, addHeader head name value)
                     )

--- a/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
+++ b/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
@@ -59,7 +59,7 @@
       <Paket>True</Paket>
       <Link>paket-files/UriUtils.fs</Link>
     </Compile>
-    <Compile Include="..\..\paket-files\fsharp\FSharp.Data\src\Net\Http.fs">
+    <Compile Include="..\..\paket-files\baronfel\FSharp.Data\src\Net\Http.fs">
       <Paket>True</Paket>
       <Link>paket-files/Http.fs</Link>
     </Compile>

--- a/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
+++ b/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
@@ -59,7 +59,7 @@
       <Paket>True</Paket>
       <Link>paket-files/UriUtils.fs</Link>
     </Compile>
-    <Compile Include="..\..\paket-files\baronfel\FSharp.Data\src\Net\Http.fs">
+    <Compile Include="..\..\paket-files\fsharp\FSharp.Data\src\Net\Http.fs">
       <Paket>True</Paket>
       <Link>paket-files/Http.fs</Link>
     </Compile>

--- a/tests/.vscode/settings.json
+++ b/tests/.vscode/settings.json
@@ -1,0 +1,4 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  fsharp
+}

--- a/tests/SwaggerProvider.ProviderTests/App.config
+++ b/tests/SwaggerProvider.ProviderTests/App.config
@@ -15,9 +15,4 @@
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.1.0" />
   </dependentAssembly>
-  <dependentAssembly>
-    <Paket>True</Paket>
-    <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.4.2.0" />
-  </dependentAssembly>
 </assemblyBinding></runtime></configuration>

--- a/tests/SwaggerProvider.ProviderTests/App.config
+++ b/tests/SwaggerProvider.ProviderTests/App.config
@@ -3,7 +3,7 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
-  
+
 <runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
   <dependentAssembly>
     <Paket>True</Paket>
@@ -14,5 +14,15 @@
     <Paket>True</Paket>
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.1.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.2.2.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.4.2.0" />
   </dependentAssembly>
 </assemblyBinding></runtime></configuration>

--- a/tests/SwaggerProvider.ProviderTests/App.config
+++ b/tests/SwaggerProvider.ProviderTests/App.config
@@ -17,11 +17,6 @@
   </dependentAssembly>
   <dependentAssembly>
     <Paket>True</Paket>
-    <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.2.2.0" />
-  </dependentAssembly>
-  <dependentAssembly>
-    <Paket>True</Paket>
     <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.4.2.0" />
   </dependentAssembly>

--- a/tests/SwaggerProvider.ProviderTests/Swagger.PetStore.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swagger.PetStore.Tests.fs
@@ -3,6 +3,9 @@
 open SwaggerProvider
 open FSharp.Data
 open Expecto
+open SwaggerProvider.Internal.Compilers
+open System.IO
+open System
 
 type PetStore = SwaggerProvider<"http://petstore.swagger.io/v2/swagger.json", "Content-Type=application/json">
 let store = PetStore()
@@ -51,4 +54,11 @@ let petStoreTests =
         Expect.equal pet.Category pet2.Category "same Category"
         Expect.equal pet.Status   pet2.Status   "same Status"
         Expect.notEqual pet pet2 "different objects"
+    
+    testCase "file Upload" <| fun _ ->
+        try
+            let result = store.UploadFile(6L, "thing", new FileWrapper("thing.jpg", new MemoryStream(Text.Encoding.UTF8.GetBytes("hello!"))))
+            printfn "%A" result
+        with
+        | exn -> ()
   ]

--- a/tests/SwaggerProvider.ProviderTests/Swashbuckle.ReturnControllers.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swashbuckle.ReturnControllers.Tests.fs
@@ -10,6 +10,7 @@ let api = WebAPI()
 let shouldEqual expected actual =
     Expect.equal actual expected "return value"
 
+
 [<Tests>]
 let returnControllersTests =
   testList "All/Swashbuckle.ReturnControllers.Tests" [

--- a/tests/Swashbuckle.OWIN.Server/App.config
+++ b/tests/Swashbuckle.OWIN.Server/App.config
@@ -15,9 +15,4 @@
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.1.0" />
   </dependentAssembly>
-  <dependentAssembly>
-    <Paket>True</Paket>
-    <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="5.2.3.0" />
-  </dependentAssembly>
 </assemblyBinding></runtime></configuration>

--- a/tests/Swashbuckle.OWIN.Server/App.config
+++ b/tests/Swashbuckle.OWIN.Server/App.config
@@ -20,25 +20,5 @@
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.1.0" />
   </dependentAssembly>
-  <dependentAssembly>
-    <Paket>True</Paket>
-    <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="3.1.0.0" />
-  </dependentAssembly>
-  <dependentAssembly>
-    <Paket>True</Paket>
-    <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.0" />
-  </dependentAssembly>
-  <dependentAssembly>
-    <Paket>True</Paket>
-    <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="5.2.3.0" />
-  </dependentAssembly>
-  <dependentAssembly>
-    <Paket>True</Paket>
-    <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="5.2.3.0" />
-  </dependentAssembly>
 </assemblyBinding></runtime>
 </configuration>

--- a/tests/Swashbuckle.OWIN.Server/App.config
+++ b/tests/Swashbuckle.OWIN.Server/App.config
@@ -3,8 +3,12 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
-  
+
 <runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+  <dependentAssembly>
+    <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="4.0.0.0" />
+  </dependentAssembly>
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -14,5 +18,25 @@
     <Paket>True</Paket>
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.1.0" />
+  </dependentAssembly>
+    <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="3.1.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="5.2.3.0" />
+  </dependentAssembly>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="5.2.3.0" />
   </dependentAssembly>
 </assemblyBinding></runtime></configuration>

--- a/tests/Swashbuckle.OWIN.Server/App.config
+++ b/tests/Swashbuckle.OWIN.Server/App.config
@@ -3,13 +3,8 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
   </startup>
-  <runtime>
-    
-  <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-  <dependentAssembly>
-    <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-    <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="4.0.0.0" />
-  </dependentAssembly>
+  
+<runtime><assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
   <dependentAssembly>
     <Paket>True</Paket>
     <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -20,5 +15,9 @@
     <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
     <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.1.0" />
   </dependentAssembly>
-</assemblyBinding></runtime>
-</configuration>
+  <dependentAssembly>
+    <Paket>True</Paket>
+    <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="5.2.3.0" />
+  </dependentAssembly>
+</assemblyBinding></runtime></configuration>

--- a/tests/Swashbuckle.OWIN.Server/Program.fs
+++ b/tests/Swashbuckle.OWIN.Server/Program.fs
@@ -3,6 +3,30 @@ open Owin
 open System
 open System.Web.Http
 open Swashbuckle.Application
+open Swashbuckle.Swagger
+
+/// A filter that sets a file response on a particular action because I don't know how to do that in swashbuckle.
+let fileDownloadFilter = 
+    { new IOperationFilter with
+            member x.Apply(operation, schemaRegistry, apiDescription) = 
+                    if operation.operationId = "ReturnFile_Get"
+                    then 
+                        operation.produces <- [| "application/octet-stream" |]
+                        operation.responses.["200"] <- Response(schema = Schema(``type`` = "file"), description = "file response")                   
+    }
+
+/// A filter that generates a body file parameter on a particular endpoint because I don't know how to set that up through swashbuckle
+let fileUploadFormFilter = 
+    { new IOperationFilter with
+            member x.Apply(operation, schemaRegistry, apiDescripion) = 
+                    if operation.operationId = "ReturnFile_Post"
+                    then 
+                        let parameter = Parameter(name = "file", ``in`` = "formData", required = Nullable<bool>(true), ``type`` = "file")
+                        if operation.parameters <> null 
+                        then operation.parameters.Add(parameter)
+                        else operation.parameters <- [| parameter |]
+                        operation.consumes.Add("multipart/form-data")
+    }
 
 
 let getAppBuilder() =
@@ -13,12 +37,15 @@ let getAppBuilder() =
     config.Routes.MapHttpRoute("default",  "api/{controller}") |> ignore
     // Enable Swagger and Swagger UI
     config
-        .EnableSwagger(fun c -> c.SingleApiVersion("v1", "Test Controllers for SwaggerProvider") |> ignore)
+        .EnableSwagger(fun c -> 
+            c.SingleApiVersion("v1", "Test Controllers for SwaggerProvider") |> ignore
+            c.OperationFilter(fun _ -> fileDownloadFilter)
+            c.OperationFilter(fun _ -> fileUploadFormFilter)
+        )
         .EnableSwaggerUi();
 
     fun (appBuilder:IAppBuilder) ->
         appBuilder.UseWebApi(config) |> ignore
-
 
 [<EntryPoint>]
 let main argv =

--- a/tests/Swashbuckle.OWIN.Server/ReturnControllers.fs
+++ b/tests/Swashbuckle.OWIN.Server/ReturnControllers.fs
@@ -1,6 +1,9 @@
 ﻿namespace Controllers
 
 open System
+open System.Collections.Generic
+open System.Net
+open System.Net.Http
 open System.Web.Http
 
 type ReturnController<'T>(value:'T) =
@@ -51,3 +54,36 @@ type ReturnObjectPointClassController () =
 
 type ReturnFileDescriptionController () =
     inherit ReturnController<Types.FileDescription>(Types.FileDescription("1.txt",[|1uy;2uy;3uy|]))
+
+/// These are special snowflakes. See the customizations we have to make in the swagger registration via filters.
+type ReturnFileController () =
+    inherit ApiController()
+     member x.Get () = 
+        let bytes = System.Text.Encoding.UTF8.GetBytes("I am totally a file's\ncontent")
+        let response = new HttpResponseMessage(HttpStatusCode.OK)
+        response.Content <- new StreamContent(new System.IO.MemoryStream(bytes))
+        response.Content.Headers.ContentType <- Headers.MediaTypeHeaderValue("application/octet-stream")
+        response
+
+    /// echoes back the first file sent
+    member x.Post () = 
+        if not <| x.Request.Content.IsMimeMultipartContent() 
+        then raise (HttpResponseException(HttpStatusCode.UnsupportedMediaType))
+        x.Request.Content.LoadIntoBufferAsync().Wait()
+        printfn "got a multipart request"
+        printfn "stream length is %d" (x.Request.Content.ReadAsStreamAsync().Result.Length)
+        let printHeader (h: KeyValuePair<string, IEnumerable<string>>) = printfn "%s: %A" h.Key h.Value
+        x.Request.Headers |> Seq.iter printHeader
+        x.Request.Content.Headers |> Seq.iter printHeader
+        
+        // Read the form data and return an async task.
+        let root = System.IO.Path.GetTempPath()
+        let multipartProvider = MultipartFormDataStreamProvider(root)
+        try
+            let written = x.Request.Content.ReadAsMultipartAsync(multipartProvider) |> Async.AwaitTask |> Async.RunSynchronously
+            written.FileData |> Seq.iter (fun fileData -> printfn "saved to %s" fileData.LocalFileName)
+            written.FileData |> Seq.map (fun fileData -> fileData.Headers.ContentDisposition.Name, fileData.Headers.ContentLength)
+        with
+        | e -> 
+            printfn "%O" e
+            raise e


### PR DESCRIPTION
I had to just make some stubs and then register their correct output schema formats after checking to see how Swashbuckle itself does it for their testing.  So it seems there's not a unified useful way to represent a 'file' yet.

but this at least generates the expected swagger formats in the doc, so it can be used as input when testing the provider.

See 
[swashbuckle file download controller](https://github.com/domaindrivendev/Swashbuckle/blob/master/Swashbuckle.Dummy.Core/Controllers/FileDownloadController.cs)
[swashbuckle file upload controller](https://github.com/domaindrivendev/Swashbuckle/blob/master/Swashbuckle.Dummy.Core/Controllers/FileUploadController.cs)
[swashbuckle file upload registrations](https://github.com/domaindrivendev/Swashbuckle/blob/master/Swashbuckle.Dummy.Core/SwaggerExtensions/AddFileUploadParams.cs)
[swashbuckle file download registrations](https://github.com/domaindrivendev/Swashbuckle/blob/master/Swashbuckle.Dummy.Core/SwaggerExtensions/UpdateFileDownloadOperations.cs)

I had to add more to our 'file download' registration because the key is to have the response be of type 'file' as well, so we can key Swagger Provider off of that.