### PR TITLE
Better support for optional parameters

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
+#### 0.8.0 - August 8, 2017
+* Better support for optional parameters [#82](https://github.com/fsprojects/SwaggerProvider/issues/82)
+
 #### 0.7.1 - June 1, 2017
-- Newtonsoft.Json v10.0.2
+* Newtonsoft.Json v10.0.2
 
 #### 0.7.0 - May 26, 2017
 * Supported Mono 5.0.1.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+os: Visual Studio 2017
+
 init:
   - git config --global core.autocrlf input
 build_script:

--- a/docs/docs.fsx
+++ b/docs/docs.fsx
@@ -5,7 +5,7 @@
 #load "../packages/build/FSharp.Formatting/FSharp.Formatting.fsx"
 #I "../packages/build/FAKE/tools/"
 #I "../packages/build/Suave/lib/net40"
-#I "../packages/build/DotLiquid/lib/NET451"
+#I "../packages/build/DotLiquid/lib/net45"
 #r "FakeLib.dll"
 #r "Suave.dll"
 #r "DotLiquid.dll"

--- a/src/Common/AssemblyInfo.fs
+++ b/src/Common/AssemblyInfo.fs
@@ -5,13 +5,13 @@ open System.Reflection
 [<assembly: AssemblyTitleAttribute("SwaggerProvider")>]
 [<assembly: AssemblyProductAttribute("SwaggerProvider")>]
 [<assembly: AssemblyDescriptionAttribute("F# Type Provider for Swagger")>]
-[<assembly: AssemblyVersionAttribute("0.7.1")>]
-[<assembly: AssemblyFileVersionAttribute("0.7.1")>]
+[<assembly: AssemblyVersionAttribute("0.8.0")>]
+[<assembly: AssemblyFileVersionAttribute("0.8.0")>]
 do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] AssemblyTitle = "SwaggerProvider"
     let [<Literal>] AssemblyProduct = "SwaggerProvider"
     let [<Literal>] AssemblyDescription = "F# Type Provider for Swagger"
-    let [<Literal>] AssemblyVersion = "0.7.1"
-    let [<Literal>] AssemblyFileVersion = "0.7.1"
+    let [<Literal>] AssemblyVersion = "0.8.0"
+    let [<Literal>] AssemblyFileVersion = "0.8.0"

--- a/src/SwaggerProvider.DesignTime/DefinitionCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/DefinitionCompiler.fs
@@ -166,3 +166,19 @@ type DefinitionCompiler (schema:SwaggerObject) =
     /// Compiles the definition.
     member __.CompileTy opName tyUseSuffix ty required =
         compileSchemaObject (uniqueName opName tyUseSuffix) ty required
+
+    /// Default value for parameters
+    member __.GetDefaultValue schemaObj =
+        match schemaObj with
+        | Boolean
+        | Byte | Int32 | Int64
+        | Float| Double 
+        | Date | DateTime
+           -> box <| None
+        | String | Enum _
+           -> box <| Unchecked.defaultof<string>
+        | File | Array _ 
+        | Dictionary _ | Object _
+        | Reference _
+           -> null
+

--- a/tests/SwaggerProvider.ProviderTests/Swashbuckle.UpdateControllers.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swashbuckle.UpdateControllers.Tests.fs
@@ -140,4 +140,11 @@ let returnControllersTests =
         let bytes = [|42uy;24uy|]
         let y = api.GetApiUpdateObjectFileDescriptionClass(bytes)
         y.Bytes |> shouldEqual bytes
+
+    testCase "Use Optional param Int" <| fun _ ->
+        api.GetApiUpdateWithOptionalInt(1)
+        |> shouldEqual 2
+
+        api.GetApiUpdateWithOptionalInt(1, Some(2))
+        |> shouldEqual 3
   ]

--- a/tests/Swashbuckle.OWIN.Server/UpdateControllers.fs
+++ b/tests/Swashbuckle.OWIN.Server/UpdateControllers.fs
@@ -2,6 +2,7 @@
 
 open System
 open System.Web.Http
+open System.Runtime.InteropServices
 
 type UpdateController<'T>(f:'T->'T) =
     inherit ApiController()
@@ -55,3 +56,10 @@ type UpdateObjectFileDescriptionClassController () =
 
     member this.Get ([<FromUri>]x) = Types.FileDescription("1.txt", x)
     member this.Post (x:Types.FileDescription) = x
+
+
+type UpdateWithOptionalIntController() =
+    inherit ApiController()
+
+    member this.Get ([<FromUri>]x, [<FromUri; Optional; DefaultParameterValue(1)>]y:int) =
+        x+y


### PR DESCRIPTION
Fix for #82

```fsharp
let [<Literal>]Schema' = "https://raw.githubusercontent.com/Krzysztof-Cieslak/SwaggerProviderOptionalQuery/master/swagger.json"
type MyTP = SwaggerProvider<Schema'>
let tp = MyTP()

tp.GetAccounts()
```

<img width="1160" alt="2017-08-08_1152" src="https://user-images.githubusercontent.com/1197905/29063946-14e34546-7c30-11e7-86c1-14b4d1238ac9.png">