### PR TITLE
Fix probing locations

### DIFF
--- a/src/SwaggerProvider/App.config
+++ b/src/SwaggerProvider/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="ProbingLocations" value="../../../Newtonsoft.Json*/lib/net45" />
+    <add key="ProbingLocations" value="../../../Newtonsoft.Json*/lib/net45;../../../../newtonsoft.json*/**/lib/net45" />
   </appSettings>
 
   <startup>


### PR DESCRIPTION
In SDK based project files NuGet packages are stored in a global nuget folder. It has bit different structure than solution local `packages` folder used in the old style of projects - it uses following format: `NAME_OF_PACKAGE/VERSION/CONTETN_OF_PACKAGE` which means that old probing location was not covering this case. 

This PR is done out of `0.8.1` version - I'd appreciate `0.8.2` release containing this fix if possible