### PR TITLE
indirectly discover the async and task generic types

### DIFF
--- a/src/SwaggerProvider.DesignTime/SwaggerProviderConfig.fs
+++ b/src/SwaggerProvider.DesignTime/SwaggerProviderConfig.fs
@@ -77,8 +77,16 @@ module private SwaggerProviderConfig =
                 ty.AddXmlDoc ("Swagger Provider for " + schema.Host)
                 ty.AddMember <| ProvidedConstructor([], invokeCode = fun _ -> <@@ () @@>)
 
+                let resolveTy asm ty = 
+                    match ctx.TryBindSimpleAssemblyNameToTarget asm with
+                    | Choice1Of2 asm -> asm.GetType(ty)
+                    | Choice2Of2 err -> raise err
+                
+                let asyncTy = resolveTy "FSharp.Core" "Microsoft.FSharp.Control.FSharpAsync`1"
+                let taskTy = resolveTy "mscorlib" "System.Threading.Tasks.Task`1" 
+
                 let defCompiler = DefinitionCompiler(schema, provideNullable)
-                let opCompiler = OperationCompiler(schema, defCompiler, ignoreControllerPrefix, ignoreOperationId, asAsync)
+                let opCompiler = OperationCompiler(schema, defCompiler, ignoreControllerPrefix, ignoreOperationId, asAsync, asyncTy, taskTy)
 
                 opCompiler.CompileProvidedClients(defCompiler.Namespace)
                 ty.AddMembers <| defCompiler.Namespace.GetProvidedTypes() // Add all provided types

--- a/tests/SwaggerProvider.Tests/Schema.Parser.Tests.fs
+++ b/tests/SwaggerProvider.Tests/Schema.Parser.Tests.fs
@@ -114,7 +114,7 @@ let parserTestBody formatParser (url:string) =
         //Number of generated types may be less than number of type definition in schema
         //TODO: Check if TPs are able to generate aliases like `type RandomInd = int`
         let defCompiler = DefinitionCompiler(schema, false)
-        let opCompiler = OperationCompiler(schema, defCompiler, true, false, asAsync = true)
+        let opCompiler = OperationCompiler(schema, defCompiler, true, false, true, typedefof<Async<_>>, typedefof<System.Threading.Tasks.Task<_>>)
         opCompiler.CompileProvidedClients(defCompiler.Namespace)
         ignore <| defCompiler.Namespace.GetProvidedTypes()
 


### PR DESCRIPTION
This PR removes an explicit dependency on the Async and Task types, opting instead to discover mscorlib and FSharp.Core from the set of Assemblies given to us at runtime, and then uses reflection to find Async<'t> and Task<'t> from those.