### PR TITLE
Use ProvidedTypeBuilder to make generic types

### DIFF
--- a/src/SwaggerProvider.DesignTime/OperationCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/OperationCompiler.fs
@@ -62,8 +62,8 @@ type OperationCompiler (schema:SwaggerObject, defCompiler:DefinitionCompiler, ig
             | None -> None
         
         let generateReturnType (retTy: Type) asAsync = 
-            if asAsync then asyncTy.MakeGenericType(retTy)
-            else taskTy.MakeGenericType(retTy)
+            if asAsync then ProvidedTypeBuilder.MakeGenericType(asyncTy, [retTy])
+            else ProvidedTypeBuilder.MakeGenericType(taskTy, [retTy])
 
         let overallReturnType = generateReturnType (defaultArg retTy (typeof<unit>)) asAsync
         let m = ProvidedMethod(methodName, parameters, overallReturnType, invokeCode = fun args ->

--- a/src/SwaggerProvider.DesignTime/SwaggerProviderConfig.fs
+++ b/src/SwaggerProvider.DesignTime/SwaggerProviderConfig.fs
@@ -77,16 +77,8 @@ module private SwaggerProviderConfig =
                 ty.AddXmlDoc ("Swagger Provider for " + schema.Host)
                 ty.AddMember <| ProvidedConstructor([], invokeCode = fun _ -> <@@ () @@>)
 
-                let resolveTy asm ty = 
-                    match ctx.TryBindSimpleAssemblyNameToTarget asm with
-                    | Choice1Of2 asm -> asm.GetType(ty)
-                    | Choice2Of2 err -> raise err
-                
-                let asyncTy = resolveTy "FSharp.Core" "Microsoft.FSharp.Control.FSharpAsync`1"
-                let taskTy = resolveTy "mscorlib" "System.Threading.Tasks.Task`1" 
-
                 let defCompiler = DefinitionCompiler(schema, provideNullable)
-                let opCompiler = OperationCompiler(schema, defCompiler, ignoreControllerPrefix, ignoreOperationId, asAsync, asyncTy, taskTy)
+                let opCompiler = OperationCompiler(schema, defCompiler, ignoreControllerPrefix, ignoreOperationId, asAsync, typedefof<Async<unit>>, typedefof<System.Threading.Tasks.Task<unit>>)
 
                 opCompiler.CompileProvidedClients(defCompiler.Namespace)
                 ty.AddMembers <| defCompiler.Namespace.GetProvidedTypes() // Add all provided types


### PR DESCRIPTION
Instead of using our own types, use `ProvidedTypeBuilder` like we do in the rest of the Type Provider.