### PR TITLE
have the template specify more precise versions, as well as only refe…

### DIFF
--- a/src/SwaggerProvider/paket.template
+++ b/src/SwaggerProvider/paket.template
@@ -26,6 +26,9 @@ files
     ../../bin/SwaggerProvider/SwaggerProvider*.* ==> lib/net45
     SwaggerProvider.fsx ==> .
 dependencies
-    FSharp.Core >= 4.0.0
-    Newtonsoft.Json ~> 10.0
-    YamlDotNet ~> 4.3.0
+    FSharp.Core ~> LOCKEDVERSION
+    Newtonsoft.Json ~> LOCKEDVERSION
+    YamlDotNet ~> LOCKEDVERSION
+references
+    SwaggerProvider.dll
+    SwaggerProvider.Runtime.dll


### PR DESCRIPTION
Change the paket.template to specify only the runtime references as you suggested. I can verify that this makes the IDE experience work!

![image](https://user-images.githubusercontent.com/573979/36161461-60e13878-10a9-11e8-80a9-9d7e69b2c9d7.png)
