### PR TITLE
Support REST convention with pluralized entities in mode with IgnoreOperationId=true

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -11,15 +11,49 @@
     <PaketRootPath>$(MSBuildThisFileDirectory)..\</PaketRootPath>
     <PaketRestoreCacheFile>$(PaketRootPath)paket-files\paket.restore.cached</PaketRestoreCacheFile>
     <PaketLockFilePath>$(PaketRootPath)paket.lock</PaketLockFilePath>
+    <PaketBootstrapperStyle>classic</PaketBootstrapperStyle>
+    <PaketBootstrapperStyle Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">proj</PaketBootstrapperStyle>
+    <PaketExeImage>assembly</PaketExeImage>
+    <PaketExeImage Condition=" '$(PaketBootstrapperStyle)' == 'proj' ">native</PaketExeImage>
     <MonoPath Condition="'$(MonoPath)' == '' And Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
     <MonoPath Condition="'$(MonoPath)' == ''">mono</MonoPath>
-    <!-- Paket command -->
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket.exe')">$(PaketRootPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' ">$(PaketToolsPath)paket.exe</PaketExePath>
-    <PaketCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketExePath)"</PaketCommand>
-    <PaketCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
+
+    <!-- PaketBootStrapper  -->
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
+    <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
+
+    <!-- Paket -->
+
+    <!-- windows, root => tool => proj style => bootstrapper => global -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(_PaketBootStrapperExeDir)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' ">paket.exe</PaketExePath>
+
+    <!-- no windows, try native paket as default,  root => tool => proj style => mono paket => bootstrpper => global -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
+
+    <!-- no windows, try mono paket -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+
+    <!-- no windows, try bootstrapper -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket.exe</PaketExePath>
+
+    <!-- no windows, try global native paket -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' ">paket</PaketExePath>
+
+    <!-- Paket command -->
+    <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
+    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</PaketCommand>
+    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
+    <PaketCommand Condition=" '$(PaketCommand)' == '' ">"$(PaketExePath)"</PaketCommand>
+
+
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
 
@@ -28,29 +62,39 @@
     <!-- see https://github.com/fsharp/fslang-design/blob/master/RFCs/FS-1032-fsharp-in-dotnet-sdk.md -->
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
+
+    <!-- Disable Paket restore under NCrunch build -->
+    <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
   </PropertyGroup>
 
-  <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" >
+  <Target Name="PaketBootstrapping" Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">
+    <MSBuild Projects="$(PaketToolsPath)paket.bootstrapper.proj" Targets="Restore" />
+  </Target>
+
+  <Target Name="PaketRestore" Condition="'$(PaketRestoreDisabled)' != 'True'" BeforeTargets="_GenerateDotnetCliToolReferenceSpecs;_GenerateProjectRestoreGraphPerFramework;_GenerateRestoreGraphWalkPerFramework;CollectPackageReferences" DependsOnTargets="PaketBootstrapping">
 
     <!-- Step 1 Check if lockfile is properly restored -->
     <PropertyGroup>
       <PaketRestoreRequired>true</PaketRestoreRequired>
-      <NoWarn>$(NoWarn);NU1603</NoWarn>
+      <NoWarn>$(NoWarn);NU1603;NU1604;NU1605;NU1608</NoWarn>
     </PropertyGroup>
 
     <!-- Because ReadAllText is slow on osx/linux, try to find shasum and awk -->
     <PropertyGroup>
-        <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketRestoreCacheFile) | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
-        <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketLockFilePath) | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
+      <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketRestoreCacheFile)" | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
+      <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketLockFilePath)" | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
     </PropertyGroup>
 
     <!-- If shasum and awk exist get the hashes -->
-    <Exec Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
-        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
+    <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
+      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
     </Exec>
-    <Exec Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
-        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
+    <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
+      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
     </Exec>
+
+    <!-- Debug whats going on -->
+    <Message Importance="low" Text="calling paket restore with targetframework=$(TargetFramework) targetframeworks=$(TargetFrameworks)" />
 
     <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
       <!-- if no hash has been done yet fall back to just reading in the files and comparing them -->
@@ -61,11 +105,26 @@
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
     </PropertyGroup>
 
+	<!-- 
+		This value should match the version in the props generated by paket 
+		If they differ, this means we need to do a restore in order to ensure correct dependencies
+	-->
+    <PropertyGroup Condition="'$(PaketPropsVersion)' != '5.185.3' ">
+      <PaketRestoreRequired>true</PaketRestoreRequired>
+    </PropertyGroup>
+
     <!-- Do a global restore if required -->
-    <Exec Command='$(PaketBootStrapperCommand)' Condition="Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
+    <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
 
     <!-- Step 2 Detect project specific changes -->
+    <ItemGroup>
+      <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>
+      <!-- Don't include all frameworks when msbuild explicitly asks for a single one -->
+      <MyTargetFrameworks Condition="'$(TargetFrameworks)' != '' AND '$(TargetFramework)' == '' " Include="$(TargetFrameworks)"></MyTargetFrameworks>
+      <PaketResolvedFilePaths Include="@(MyTargetFrameworks -> '$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).%(Identity).paket.resolved')"></PaketResolvedFilePaths>
+    </ItemGroup>
+    <Message Importance="low" Text="MyTargetFrameworks=@(MyTargetFrameworks) PaketResolvedFilePaths=@(PaketResolvedFilePaths)" />
     <PropertyGroup>
       <PaketReferencesCachedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).paket.references.cached</PaketReferencesCachedFilePath>
       <!-- MyProject.fsproj.paket.references has the highest precedence -->
@@ -74,7 +133,9 @@
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\$(MSBuildProjectName).paket.references</PaketOriginalReferencesFilePath>
       <!-- paket.references -->
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\paket.references</PaketOriginalReferencesFilePath>
-      <PaketResolvedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).$(TargetFramework).paket.resolved</PaketResolvedFilePath>
+
+      <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
+      <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
       <PaketRestoreRequired>true</PaketRestoreRequired>
       <PaketRestoreRequiredReason>references-file-or-cache-not-found</PaketRestoreRequiredReason>
     </PropertyGroup>
@@ -93,30 +154,43 @@
     </PropertyGroup>
 
     <!-- Step 2 b detect relevant changes in project file (new targetframework) -->
-    <PropertyGroup Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' ">
+    <PropertyGroup Condition=" '$(DoAllResolvedFilesExist)' != 'true' ">
       <PaketRestoreRequired>true</PaketRestoreRequired>
-      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)'</PaketRestoreRequiredReason>
+      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)' or '$(TargetFrameworks)' files @(PaketResolvedFilePaths)</PaketRestoreRequiredReason>
     </PropertyGroup>
 
     <!-- Step 3 Restore project specific stuff if required -->
     <Message Condition=" '$(PaketRestoreRequired)' == 'true' " Importance="low" Text="Detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)', calling paket restore" />
-    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)"' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework "$(TargetFrameworks)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' == '' " ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework "$(TargetFramework)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' != '' " ContinueOnError="false" />
 
     <!-- This shouldn't actually happen, but just to be sure. -->
-    <Error Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' AND '$(ResolveNuGetPackages)' != 'False' " Text="Paket file '$(PaketResolvedFilePath)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
+    <PropertyGroup>
+      <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
+      <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
+    </PropertyGroup>
+    <Error Condition=" '$(DoAllResolvedFilesExist)' != 'true' AND '$(ResolveNuGetPackages)' != 'False' " Text="One Paket file '@(PaketResolvedFilePaths)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
 
     <!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
-    <ReadLinesFromFile Condition="Exists('$(PaketResolvedFilePath)')" File="$(PaketResolvedFilePath)" >
+    <ReadLinesFromFile Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketResolvedFilePaths)' != ''" File="%(PaketResolvedFilePaths.Identity)" >
       <Output TaskParameter="Lines" ItemName="PaketReferencesFileLines"/>
     </ReadLinesFromFile>
 
-    <ItemGroup Condition=" Exists('$(PaketResolvedFilePath)') AND '@(PaketReferencesFileLines)' != '' " >
+    <ItemGroup Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketReferencesFileLines)' != '' " >
       <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
+        <Splits>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',').Length)</Splits>
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
+        <AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
+        <CopyLocal Condition="'$(Splits)' == '6'">$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[5])</CopyLocal>
       </PaketReferencesFileLinesInfo>
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
+        <PrivateAssets Condition=" ('%(PaketReferencesFileLinesInfo.AllPrivateAssets)' == 'true') Or ('$(PackAsTool)' == 'true') ">All</PrivateAssets>
+        <ExcludeAssets Condition=" '%(PaketReferencesFileLinesInfo.Splits)' == '6' And %(PaketReferencesFileLinesInfo.CopyLocal) == 'false'">runtime</ExcludeAssets>
+        <ExcludeAssets Condition=" '%(PaketReferencesFileLinesInfo.Splits)' != '6' And %(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'exclude'">runtime</ExcludeAssets>
+        <Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
+        <AllowExplicitVersion>true</AllowExplicitVersion>
       </PackageReference>
     </ItemGroup>
 
@@ -138,28 +212,37 @@
       </DotNetCliToolReference>
     </ItemGroup>
 
+    <!-- Disabled for now until we know what to do with runtime deps - https://github.com/fsprojects/Paket/issues/2964
     <PropertyGroup>
       <RestoreConfigFile>$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).NuGet.Config</RestoreConfigFile>
-    </PropertyGroup>
+    </PropertyGroup> -->
 
   </Target>
 
   <Target Name="PaketDisableDirectPack" AfterTargets="_IntermediatePack" BeforeTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
     <PropertyGroup>
       <ContinuePackingAfterGeneratingNuspec>false</ContinuePackingAfterGeneratingNuspec>
+      <DetectedMSBuildVersion>$(MSBuildVersion)</DetectedMSBuildVersion>
+      <DetectedMSBuildVersion Condition="$(MSBuildVersion) == ''">15.8.0</DetectedMSBuildVersion>
     </PropertyGroup>
   </Target>
 
   <Target Name="PaketOverrideNuspec" AfterTargets="GenerateNuspec" Condition="('$(IsPackable)' == '' Or '$(IsPackable)' == 'true') And Exists('$(MSBuildProjectDirectory)/obj/$(MSBuildProjectFile).references')" >
     <ItemGroup>
       <_NuspecFilesNewLocation Include="$(BaseIntermediateOutputPath)$(Configuration)\*.nuspec"/>
+      <MSBuildMajorVersion Include="$(DetectedMSBuildVersion.Replace(`-`, `.`).Split(`.`)[0])" />
+      <MSBuildMinorVersion Include="$(DetectedMSBuildVersion.Replace(`-`, `.`).Split(`.`)[1])" />
     </ItemGroup>
 
     <PropertyGroup>
       <PaketProjectFile>$(MSBuildProjectDirectory)/$(MSBuildProjectFile)</PaketProjectFile>
       <ContinuePackingAfterGeneratingNuspec>true</ContinuePackingAfterGeneratingNuspec>
-      <UseNewPack>false</UseNewPack>
-      <UseNewPack Condition=" '$(NuGetToolVersion)' != '4.0.0' ">true</UseNewPack>
+      <UseMSBuild15_9_Pack>false</UseMSBuild15_9_Pack>
+      <UseMSBuild15_9_Pack Condition=" '@(MSBuildMajorVersion)' > '15' OR ('@(MSBuildMajorVersion)' == '15' AND '@(MSBuildMinorVersion)' > '8') ">true</UseMSBuild15_9_Pack>
+      <UseMSBuild15_8_Pack>false</UseMSBuild15_8_Pack>
+      <UseMSBuild15_8_Pack Condition=" '$(NuGetToolVersion)' != '4.0.0' AND (! $(UseMSBuild15_9_Pack)) ">true</UseMSBuild15_8_Pack>
+      <UseNuGet4_Pack>false</UseNuGet4_Pack>
+      <UseNuGet4_Pack Condition=" (! $(UseMSBuild15_8_Pack)) AND (! $(UseMSBuild15_9_Pack)) ">true</UseNuGet4_Pack>
       <AdjustedNuspecOutputPath>$(BaseIntermediateOutputPath)$(Configuration)</AdjustedNuspecOutputPath>
       <AdjustedNuspecOutputPath Condition="@(_NuspecFilesNewLocation) == ''">$(BaseIntermediateOutputPath)</AdjustedNuspecOutputPath>
     </PropertyGroup>
@@ -172,11 +255,54 @@
 
     <ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">
       <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
-    </ConvertToAbsolutePath>      
-        
+    </ConvertToAbsolutePath>
 
     <!-- Call Pack -->
-    <PackTask Condition="$(UseNewPack)"
+    <PackTask Condition="$(UseMSBuild15_9_Pack)"
+              PackItem="$(PackProjectInputFile)"
+              PackageFiles="@(_PackageFiles)"
+              PackageFilesToExclude="@(_PackageFilesToExclude)"
+              PackageVersion="$(PackageVersion)"
+              PackageId="$(PackageId)"
+              Title="$(Title)"
+              Authors="$(Authors)"
+              Description="$(Description)"
+              Copyright="$(Copyright)"
+              RequireLicenseAcceptance="$(PackageRequireLicenseAcceptance)"
+              LicenseUrl="$(PackageLicenseUrl)"
+              ProjectUrl="$(PackageProjectUrl)"
+              IconUrl="$(PackageIconUrl)"
+              ReleaseNotes="$(PackageReleaseNotes)"
+              Tags="$(PackageTags)"
+              DevelopmentDependency="$(DevelopmentDependency)"
+              BuildOutputInPackage="@(_BuildOutputInPackage)"
+              TargetPathsToSymbols="@(_TargetPathsToSymbols)"
+              SymbolPackageFormat="symbols.nupkg"
+              TargetFrameworks="@(_TargetFrameworks)"
+              AssemblyName="$(AssemblyName)"
+              PackageOutputPath="$(PackageOutputAbsolutePath)"
+              IncludeSymbols="$(IncludeSymbols)"
+              IncludeSource="$(IncludeSource)"
+              PackageTypes="$(PackageType)"
+              IsTool="$(IsTool)"
+              RepositoryUrl="$(RepositoryUrl)"
+              RepositoryType="$(RepositoryType)"
+              SourceFiles="@(_SourceFiles->Distinct())"
+              NoPackageAnalysis="$(NoPackageAnalysis)"
+              MinClientVersion="$(MinClientVersion)"
+              Serviceable="$(Serviceable)"
+              FrameworkAssemblyReferences="@(_FrameworkAssemblyReferences)"
+              ContinuePackingAfterGeneratingNuspec="$(ContinuePackingAfterGeneratingNuspec)"
+              NuspecOutputPath="$(AdjustedNuspecOutputPath)"
+              IncludeBuildOutput="$(IncludeBuildOutput)"
+              BuildOutputFolder="$(BuildOutputTargetFolder)"
+              ContentTargetFolders="$(ContentTargetFolders)"
+              RestoreOutputPath="$(RestoreOutputAbsolutePath)"
+              NuspecFile="$(NuspecFileAbsolutePath)"
+              NuspecBasePath="$(NuspecBasePath)"
+              NuspecProperties="$(NuspecProperties)"/>
+
+    <PackTask Condition="$(UseMSBuild15_8_Pack)"
               PackItem="$(PackProjectInputFile)"
               PackageFiles="@(_PackageFiles)"
               PackageFilesToExclude="@(_PackageFilesToExclude)"
@@ -219,7 +345,7 @@
               NuspecBasePath="$(NuspecBasePath)"
               NuspecProperties="$(NuspecProperties)"/>
 
-    <PackTask Condition="! $(UseNewPack)"
+    <PackTask Condition="$(UseNuGet4_Pack)"
               PackItem="$(PackProjectInputFile)"
               PackageFiles="@(_PackageFiles)"
               PackageFilesToExclude="@(_PackageFilesToExclude)"

--- a/tests/SwaggerProvider.ProviderTests/Swagger.PetStore.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/Swagger.PetStore.Tests.fs
@@ -15,7 +15,7 @@ let petStoreTests =
   testList "All/TP PetStore Tests" [
 
     testCase "Test provided Host property" <| fun _ ->
-        Expect.equal store.Host "http://petstore.swagger.io" "value from schema"
+        Expect.equal store.Host "https://petstore.swagger.io" "value from schema"
         store.Host <- "https://petstore.swagger.io"
         Expect.equal store.Host "https://petstore.swagger.io" "Modified value"
         store.Host <- "http://petstore.swagger.io"

--- a/tests/SwaggerProvider.Tests/Schemas/PetStore.Swagger.json
+++ b/tests/SwaggerProvider.Tests/Schemas/PetStore.Swagger.json
@@ -1,717 +1,868 @@
 {
-    "swagger": "2.0",
-    "info": {
-        "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
-        "version": "1.0.0",
-        "title": "Swagger Petstore",
-        "termsOfService": "http://swagger.io/terms/",
-        "contact": { "email": "apiteam@swagger.io" },
-        "license": {
-            "name": "Apache 2.0",
-            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-        }
-    },
-    "host": "petstore.swagger.io",
-    "basePath": "/v2",
-    "tags": [
-        {
-            "name": "pet",
-            "description": "Everything about your Pets",
-            "externalDocs": {
-                "description": "Find out more",
-                "url": "http://swagger.io"
-            }
-        },
-        {
-            "name": "store",
-            "description": "Access to Petstore orders"
-        },
-        {
-            "name": "user",
-            "description": "Operations about user",
-            "externalDocs": {
-                "description": "Find out more about our store",
-                "url": "http://swagger.io"
-            }
-        }
-    ],
-    "schemes": [ "http" ],
-    "paths": {
-        "/pet": {
-            "post": {
-                "tags": [ "pet" ],
-                "summary": "Add a new pet to the store",
-                "description": "",
-                "operationId": "addPet",
-                "consumes": [ "application/json", "application/xml" ],
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "Pet object that needs to be added to the store",
-                        "required": true,
-                        "schema": { "$ref": "#/definitions/Pet" }
-                    }
-                ],
-                "responses": { "405": { "description": "Invalid input" } },
-                "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
-            },
-            "put": {
-                "tags": [ "pet" ],
-                "summary": "Update an existing pet",
-                "description": "",
-                "operationId": "updatePet",
-                "consumes": [ "application/json", "application/xml" ],
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "Pet object that needs to be added to the store",
-                        "required": true,
-                        "schema": { "$ref": "#/definitions/Pet" }
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Invalid ID supplied" },
-                    "404": { "description": "Pet not found" },
-                    "405": { "description": "Validation exception" }
-                },
-                "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
-            }
-        },
-        "/pet/findByStatus": {
-            "get": {
-                "tags": [ "pet" ],
-                "summary": "Finds Pets by status",
-                "description": "Multiple status values can be provided with comma separated strings",
-                "operationId": "findPetsByStatus",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "name": "status",
-                        "in": "query",
-                        "description": "Status values that need to be considered for filter",
-                        "required": true,
-                        "type": "array",
-                        "items": {
-                            "type": "string",
-                            "enum": [ "available", "pending", "sold" ],
-                            "default": "available"
-                        },
-                        "collectionFormat": "multi"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "successful operation",
-                        "schema": {
-                            "type": "array",
-                            "items": { "$ref": "#/definitions/Pet" }
-                        }
-                    },
-                    "400": { "description": "Invalid status value" }
-                },
-                "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
-            }
-        },
-        "/pet/findByTags": {
-            "get": {
-                "tags": [ "pet" ],
-                "summary": "Finds Pets by tags",
-                "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
-                "operationId": "findPetsByTags",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "name": "tags",
-                        "in": "query",
-                        "description": "Tags to filter by",
-                        "required": true,
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "collectionFormat": "multi"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "successful operation",
-                        "schema": {
-                            "type": "array",
-                            "items": { "$ref": "#/definitions/Pet" }
-                        }
-                    },
-                    "400": { "description": "Invalid tag value" }
-                },
-                "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ],
-                "deprecated": true
-            }
-        },
-        "/pet/{petId}": {
-            "get": {
-                "tags": [ "pet" ],
-                "summary": "Find pet by ID",
-                "description": "Returns a single pet",
-                "operationId": "getPetById",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "name": "petId",
-                        "in": "path",
-                        "description": "ID of pet to return",
-                        "required": true,
-                        "type": "integer",
-                        "format": "int64"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "successful operation",
-                        "schema": { "$ref": "#/definitions/Pet" }
-                    },
-                    "400": { "description": "Invalid ID supplied" },
-                    "404": { "description": "Pet not found" }
-                },
-                "security": [ { "api_key": [ ] } ]
-            },
-            "post": {
-                "tags": [ "pet" ],
-                "summary": "Updates a pet in the store with form data",
-                "description": "",
-                "operationId": "updatePetWithForm",
-                "consumes": [ "application/x-www-form-urlencoded" ],
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "name": "petId",
-                        "in": "path",
-                        "description": "ID of pet that needs to be updated",
-                        "required": true,
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    {
-                        "name": "name",
-                        "in": "formData",
-                        "description": "Updated name of the pet",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "status",
-                        "in": "formData",
-                        "description": "Updated status of the pet",
-                        "required": false,
-                        "type": "string"
-                    }
-                ],
-                "responses": { "405": { "description": "Invalid input" } },
-                "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
-            },
-            "delete": {
-                "tags": [ "pet" ],
-                "summary": "Deletes a pet",
-                "description": "",
-                "operationId": "deletePet",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "name": "api_key",
-                        "in": "header",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "petId",
-                        "in": "path",
-                        "description": "Pet id to delete",
-                        "required": true,
-                        "type": "integer",
-                        "format": "int64"
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Invalid ID supplied" },
-                    "404": { "description": "Pet not found" }
-                },
-                "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
-            }
-        },
-        "/pet/{petId}/uploadImage": {
-            "post": {
-                "tags": [ "pet" ],
-                "summary": "uploads an image",
-                "description": "",
-                "operationId": "uploadFile",
-                "consumes": [ "multipart/form-data" ],
-                "produces": [ "application/json" ],
-                "parameters": [
-                    {
-                        "name": "petId",
-                        "in": "path",
-                        "description": "ID of pet to update",
-                        "required": true,
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    {
-                        "name": "additionalMetadata",
-                        "in": "formData",
-                        "description": "Additional data to pass to server",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "file",
-                        "in": "formData",
-                        "description": "file to upload",
-                        "required": false,
-                        "type": "file"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "successful operation",
-                        "schema": { "$ref": "#/definitions/ApiResponse" }
-                    }
-                },
-                "security": [ { "petstore_auth": [ "write:pets", "read:pets" ] } ]
-            }
-        },
-        "/store/inventory": {
-            "get": {
-                "tags": [ "store" ],
-                "summary": "Returns pet inventories by status",
-                "description": "Returns a map of status codes to quantities",
-                "operationId": "getInventory",
-                "produces": [ "application/json" ],
-                "parameters": [ ],
-                "responses": {
-                    "200": {
-                        "description": "successful operation",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "integer",
-                                "format": "int32"
-                            }
-                        }
-                    }
-                },
-                "security": [ { "api_key": [ ] } ]
-            }
-        },
-        "/store/order": {
-            "post": {
-                "tags": [ "store" ],
-                "summary": "Place an order for a pet",
-                "description": "",
-                "operationId": "placeOrder",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "order placed for purchasing the pet",
-                        "required": true,
-                        "schema": { "$ref": "#/definitions/Order" }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "successful operation",
-                        "schema": { "$ref": "#/definitions/Order" }
-                    },
-                    "400": { "description": "Invalid Order" }
-                }
-            }
-        },
-        "/store/order/{orderId}": {
-            "get": {
-                "tags": [ "store" ],
-                "summary": "Find purchase order by ID",
-                "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
-                "operationId": "getOrderById",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "name": "orderId",
-                        "in": "path",
-                        "description": "ID of pet that needs to be fetched",
-                        "required": true,
-                        "type": "integer",
-                        "maximum": 10.0,
-                        "minimum": 1.0,
-                        "format": "int64"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "successful operation",
-                        "schema": { "$ref": "#/definitions/Order" }
-                    },
-                    "400": { "description": "Invalid ID supplied" },
-                    "404": { "description": "Order not found" }
-                }
-            },
-            "delete": {
-                "tags": [ "store" ],
-                "summary": "Delete purchase order by ID",
-                "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
-                "operationId": "deleteOrder",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "name": "orderId",
-                        "in": "path",
-                        "description": "ID of the order that needs to be deleted",
-                        "required": true,
-                        "type": "integer",
-                        "minimum": 1.0,
-                        "format": "int64"
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Invalid ID supplied" },
-                    "404": { "description": "Order not found" }
-                }
-            }
-        },
-        "/user": {
-            "post": {
-                "tags": [ "user" ],
-                "summary": "Create user",
-                "description": "This can only be done by the logged in user.",
-                "operationId": "createUser",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "Created user object",
-                        "required": true,
-                        "schema": { "$ref": "#/definitions/User" }
-                    }
-                ],
-                "responses": { "default": { "description": "successful operation" } }
-            }
-        },
-        "/user/createWithArray": {
-            "post": {
-                "tags": [ "user" ],
-                "summary": "Creates list of users with given input array",
-                "description": "",
-                "operationId": "createUsersWithArrayInput",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "List of user object",
-                        "required": true,
-                        "schema": {
-                            "type": "array",
-                            "items": { "$ref": "#/definitions/User" }
-                        }
-                    }
-                ],
-                "responses": { "default": { "description": "successful operation" } }
-            }
-        },
-        "/user/createWithList": {
-            "post": {
-                "tags": [ "user" ],
-                "summary": "Creates list of users with given input array",
-                "description": "",
-                "operationId": "createUsersWithListInput",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "List of user object",
-                        "required": true,
-                        "schema": {
-                            "type": "array",
-                            "items": { "$ref": "#/definitions/User" }
-                        }
-                    }
-                ],
-                "responses": { "default": { "description": "successful operation" } }
-            }
-        },
-        "/user/login": {
-            "get": {
-                "tags": [ "user" ],
-                "summary": "Logs user into the system",
-                "description": "",
-                "operationId": "loginUser",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "name": "username",
-                        "in": "query",
-                        "description": "The user name for login",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "password",
-                        "in": "query",
-                        "description": "The password for login in clear text",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "successful operation",
-                        "schema": { "type": "string" },
-                        "headers": {
-                            "X-Rate-Limit": {
-                                "type": "integer",
-                                "format": "int32",
-                                "description": "calls per hour allowed by the user"
-                            },
-                            "X-Expires-After": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "date in UTC when token expires"
-                            }
-                        }
-                    },
-                    "400": { "description": "Invalid username/password supplied" }
-                }
-            }
-        },
-        "/user/logout": {
-            "get": {
-                "tags": [ "user" ],
-                "summary": "Logs out current logged in user session",
-                "description": "",
-                "operationId": "logoutUser",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [ ],
-                "responses": { "default": { "description": "successful operation" } }
-            }
-        },
-        "/user/{username}": {
-            "get": {
-                "tags": [ "user" ],
-                "summary": "Get user by user name",
-                "description": "",
-                "operationId": "getUserByName",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "name": "username",
-                        "in": "path",
-                        "description": "The name that needs to be fetched. Use user1 for testing. ",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "successful operation",
-                        "schema": { "$ref": "#/definitions/User" }
-                    },
-                    "400": { "description": "Invalid username supplied" },
-                    "404": { "description": "User not found" }
-                }
-            },
-            "put": {
-                "tags": [ "user" ],
-                "summary": "Updated user",
-                "description": "This can only be done by the logged in user.",
-                "operationId": "updateUser",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "name": "username",
-                        "in": "path",
-                        "description": "name that need to be updated",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "in": "body",
-                        "name": "body",
-                        "description": "Updated user object",
-                        "required": true,
-                        "schema": { "$ref": "#/definitions/User" }
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Invalid user supplied" },
-                    "404": { "description": "User not found" }
-                }
-            },
-            "delete": {
-                "tags": [ "user" ],
-                "summary": "Delete user",
-                "description": "This can only be done by the logged in user.",
-                "operationId": "deleteUser",
-                "produces": [ "application/xml", "application/json" ],
-                "parameters": [
-                    {
-                        "name": "username",
-                        "in": "path",
-                        "description": "The name that needs to be deleted",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
-                "responses": {
-                    "400": { "description": "Invalid username supplied" },
-                    "404": { "description": "User not found" }
-                }
-            }
-        }
-    },
-    "securityDefinitions": {
-        "petstore_auth": {
-            "type": "oauth2",
-            "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
-            "flow": "implicit",
-            "scopes": {
-                "write:pets": "modify pets in your account",
-                "read:pets": "read your pets"
-            }
-        },
-        "api_key": {
-            "type": "apiKey",
-            "name": "api_key",
-            "in": "header"
-        }
-    },
-    "definitions": {
-        "Order": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "petId": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "quantity": {
-                    "type": "integer",
-                    "format": "int32"
-                },
-                "shipDate": {
-                    "type": "string",
-                    "format": "date-time"
-                },
-                "status": {
-                    "type": "string",
-                    "description": "Order Status",
-                    "enum": [ "placed", "approved", "delivered" ]
-                },
-                "complete": {
-                    "type": "boolean",
-                    "default": false
-                }
-            },
-            "xml": { "name": "Order" }
-        },
-        "User": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "username": { "type": "string" },
-                "firstName": { "type": "string" },
-                "lastName": { "type": "string" },
-                "email": { "type": "string" },
-                "password": { "type": "string" },
-                "phone": { "type": "string" },
-                "userStatus": {
-                    "type": "integer",
-                    "format": "int32",
-                    "description": "User Status"
-                }
-            },
-            "xml": { "name": "User" }
-        },
-        "Category": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "name": { "type": "string" }
-            },
-            "xml": { "name": "Category" }
-        },
-        "Tag": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "name": { "type": "string" }
-            },
-            "xml": { "name": "Tag" }
-        },
-        "Pet": {
-            "type": "object",
-            "required": [ "name", "photoUrls" ],
-            "properties": {
-                "id": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "category": { "$ref": "#/definitions/Category" },
-                "name": {
-                    "type": "string",
-                    "example": "doggie"
-                },
-                "photoUrls": {
-                    "type": "array",
-                    "xml": {
-                        "name": "photoUrl",
-                        "wrapped": true
-                    },
-                    "items": { "type": "string" }
-                },
-                "tags": {
-                    "type": "array",
-                    "xml": {
-                        "name": "tag",
-                        "wrapped": true
-                    },
-                    "items": { "$ref": "#/definitions/Tag" }
-                },
-                "status": {
-                    "type": "string",
-                    "description": "pet status in the store",
-                    "enum": [ "available", "pending", "sold" ]
-                }
-            },
-            "xml": { "name": "Pet" }
-        },
-        "ApiResponse": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "integer",
-                    "format": "int32"
-                },
-                "type": { "type": "string" },
-                "message": { "type": "string" }
-            }
-        }
-    },
-    "externalDocs": {
-        "description": "Find out more about Swagger",
-        "url": "http://swagger.io"
-    }
+	"swagger": "2.0",
+	"info": {
+		"description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+		"version": "1.0.0",
+		"title": "Swagger Petstore",
+		"termsOfService": "http://swagger.io/terms/",
+		"contact": {
+			"email": "apiteam@swagger.io"
+		},
+		"license": {
+			"name": "Apache 2.0",
+			"url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+		}
+	},
+	"host": "petstore.swagger.io",
+	"basePath": "/v2",
+	"tags": [{
+		"name": "pet",
+		"description": "Everything about your Pets",
+		"externalDocs": {
+			"description": "Find out more",
+			"url": "http://swagger.io"
+		}
+	},
+	{
+		"name": "store",
+		"description": "Access to Petstore orders"
+	},
+	{
+		"name": "user",
+		"description": "Operations about user",
+		"externalDocs": {
+			"description": "Find out more about our store",
+			"url": "http://swagger.io"
+		}
+	}],
+	"schemes": ["https",
+	"http"],
+	"paths": {
+		"/pet": {
+			"post": {
+				"tags": ["pet"],
+				"summary": "Add a new pet to the store",
+				"description": "",
+				"operationId": "addPet",
+				"consumes": ["application/json",
+				"application/xml"],
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"in": "body",
+					"name": "body",
+					"description": "Pet object that needs to be added to the store",
+					"required": true,
+					"schema": {
+						"$ref": "#/definitions/Pet"
+					}
+				}],
+				"responses": {
+					"405": {
+						"description": "Invalid input"
+					}
+				},
+				"security": [{
+					"petstore_auth": ["write:pets",
+					"read:pets"]
+				}]
+			},
+			"put": {
+				"tags": ["pet"],
+				"summary": "Update an existing pet",
+				"description": "",
+				"operationId": "updatePet",
+				"consumes": ["application/json",
+				"application/xml"],
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"in": "body",
+					"name": "body",
+					"description": "Pet object that needs to be added to the store",
+					"required": true,
+					"schema": {
+						"$ref": "#/definitions/Pet"
+					}
+				}],
+				"responses": {
+					"400": {
+						"description": "Invalid ID supplied"
+					},
+					"404": {
+						"description": "Pet not found"
+					},
+					"405": {
+						"description": "Validation exception"
+					}
+				},
+				"security": [{
+					"petstore_auth": ["write:pets",
+					"read:pets"]
+				}]
+			}
+		},
+		"/pet/findByStatus": {
+			"get": {
+				"tags": ["pet"],
+				"summary": "Finds Pets by status",
+				"description": "Multiple status values can be provided with comma separated strings",
+				"operationId": "findPetsByStatus",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"name": "status",
+					"in": "query",
+					"description": "Status values that need to be considered for filter",
+					"required": true,
+					"type": "array",
+					"items": {
+						"type": "string",
+						"enum": ["available",
+						"pending",
+						"sold"],
+						"default": "available"
+					},
+					"collectionFormat": "multi"
+				}],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/Pet"
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid status value"
+					}
+				},
+				"security": [{
+					"petstore_auth": ["write:pets",
+					"read:pets"]
+				}]
+			}
+		},
+		"/pet/findByTags": {
+			"get": {
+				"tags": ["pet"],
+				"summary": "Finds Pets by tags",
+				"description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+				"operationId": "findPetsByTags",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"name": "tags",
+					"in": "query",
+					"description": "Tags to filter by",
+					"required": true,
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"collectionFormat": "multi"
+				}],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"schema": {
+							"type": "array",
+							"items": {
+								"$ref": "#/definitions/Pet"
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid tag value"
+					}
+				},
+				"security": [{
+					"petstore_auth": ["write:pets",
+					"read:pets"]
+				}],
+				"deprecated": true
+			}
+		},
+		"/pet/{petId}": {
+			"get": {
+				"tags": ["pet"],
+				"summary": "Find pet by ID",
+				"description": "Returns a single pet",
+				"operationId": "getPetById",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"name": "petId",
+					"in": "path",
+					"description": "ID of pet to return",
+					"required": true,
+					"type": "integer",
+					"format": "int64"
+				}],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"schema": {
+							"$ref": "#/definitions/Pet"
+						}
+					},
+					"400": {
+						"description": "Invalid ID supplied"
+					},
+					"404": {
+						"description": "Pet not found"
+					}
+				},
+				"security": [{
+					"api_key": []
+				}]
+			},
+			"post": {
+				"tags": ["pet"],
+				"summary": "Updates a pet in the store with form data",
+				"description": "",
+				"operationId": "updatePetWithForm",
+				"consumes": ["application/x-www-form-urlencoded"],
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"name": "petId",
+					"in": "path",
+					"description": "ID of pet that needs to be updated",
+					"required": true,
+					"type": "integer",
+					"format": "int64"
+				},
+				{
+					"name": "name",
+					"in": "formData",
+					"description": "Updated name of the pet",
+					"required": false,
+					"type": "string"
+				},
+				{
+					"name": "status",
+					"in": "formData",
+					"description": "Updated status of the pet",
+					"required": false,
+					"type": "string"
+				}],
+				"responses": {
+					"405": {
+						"description": "Invalid input"
+					}
+				},
+				"security": [{
+					"petstore_auth": ["write:pets",
+					"read:pets"]
+				}]
+			},
+			"delete": {
+				"tags": ["pet"],
+				"summary": "Deletes a pet",
+				"description": "",
+				"operationId": "deletePet",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"name": "api_key",
+					"in": "header",
+					"required": false,
+					"type": "string"
+				},
+				{
+					"name": "petId",
+					"in": "path",
+					"description": "Pet id to delete",
+					"required": true,
+					"type": "integer",
+					"format": "int64"
+				}],
+				"responses": {
+					"400": {
+						"description": "Invalid ID supplied"
+					},
+					"404": {
+						"description": "Pet not found"
+					}
+				},
+				"security": [{
+					"petstore_auth": ["write:pets",
+					"read:pets"]
+				}]
+			}
+		},
+		"/pet/{petId}/uploadImage": {
+			"post": {
+				"tags": ["pet"],
+				"summary": "uploads an image",
+				"description": "",
+				"operationId": "uploadFile",
+				"consumes": ["multipart/form-data"],
+				"produces": ["application/json"],
+				"parameters": [{
+					"name": "petId",
+					"in": "path",
+					"description": "ID of pet to update",
+					"required": true,
+					"type": "integer",
+					"format": "int64"
+				},
+				{
+					"name": "additionalMetadata",
+					"in": "formData",
+					"description": "Additional data to pass to server",
+					"required": false,
+					"type": "string"
+				},
+				{
+					"name": "file",
+					"in": "formData",
+					"description": "file to upload",
+					"required": false,
+					"type": "file"
+				}],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"schema": {
+							"$ref": "#/definitions/ApiResponse"
+						}
+					}
+				},
+				"security": [{
+					"petstore_auth": ["write:pets",
+					"read:pets"]
+				}]
+			}
+		},
+		"/store/inventory": {
+			"get": {
+				"tags": ["store"],
+				"summary": "Returns pet inventories by status",
+				"description": "Returns a map of status codes to quantities",
+				"operationId": "getInventory",
+				"produces": ["application/json"],
+				"parameters": [],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"schema": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "integer",
+								"format": "int32"
+							}
+						}
+					}
+				},
+				"security": [{
+					"api_key": []
+				}]
+			}
+		},
+		"/store/order": {
+			"post": {
+				"tags": ["store"],
+				"summary": "Place an order for a pet",
+				"description": "",
+				"operationId": "placeOrder",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"in": "body",
+					"name": "body",
+					"description": "order placed for purchasing the pet",
+					"required": true,
+					"schema": {
+						"$ref": "#/definitions/Order"
+					}
+				}],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"schema": {
+							"$ref": "#/definitions/Order"
+						}
+					},
+					"400": {
+						"description": "Invalid Order"
+					}
+				}
+			}
+		},
+		"/store/order/{orderId}": {
+			"get": {
+				"tags": ["store"],
+				"summary": "Find purchase order by ID",
+				"description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
+				"operationId": "getOrderById",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"name": "orderId",
+					"in": "path",
+					"description": "ID of pet that needs to be fetched",
+					"required": true,
+					"type": "integer",
+					"maximum": 10.0,
+					"minimum": 1.0,
+					"format": "int64"
+				}],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"schema": {
+							"$ref": "#/definitions/Order"
+						}
+					},
+					"400": {
+						"description": "Invalid ID supplied"
+					},
+					"404": {
+						"description": "Order not found"
+					}
+				}
+			},
+			"delete": {
+				"tags": ["store"],
+				"summary": "Delete purchase order by ID",
+				"description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
+				"operationId": "deleteOrder",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"name": "orderId",
+					"in": "path",
+					"description": "ID of the order that needs to be deleted",
+					"required": true,
+					"type": "integer",
+					"minimum": 1.0,
+					"format": "int64"
+				}],
+				"responses": {
+					"400": {
+						"description": "Invalid ID supplied"
+					},
+					"404": {
+						"description": "Order not found"
+					}
+				}
+			}
+		},
+		"/user": {
+			"post": {
+				"tags": ["user"],
+				"summary": "Create user",
+				"description": "This can only be done by the logged in user.",
+				"operationId": "createUser",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"in": "body",
+					"name": "body",
+					"description": "Created user object",
+					"required": true,
+					"schema": {
+						"$ref": "#/definitions/User"
+					}
+				}],
+				"responses": {
+					"default": {
+						"description": "successful operation"
+					}
+				}
+			}
+		},
+		"/user/createWithArray": {
+			"post": {
+				"tags": ["user"],
+				"summary": "Creates list of users with given input array",
+				"description": "",
+				"operationId": "createUsersWithArrayInput",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"in": "body",
+					"name": "body",
+					"description": "List of user object",
+					"required": true,
+					"schema": {
+						"type": "array",
+						"items": {
+							"$ref": "#/definitions/User"
+						}
+					}
+				}],
+				"responses": {
+					"default": {
+						"description": "successful operation"
+					}
+				}
+			}
+		},
+		"/user/createWithList": {
+			"post": {
+				"tags": ["user"],
+				"summary": "Creates list of users with given input array",
+				"description": "",
+				"operationId": "createUsersWithListInput",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"in": "body",
+					"name": "body",
+					"description": "List of user object",
+					"required": true,
+					"schema": {
+						"type": "array",
+						"items": {
+							"$ref": "#/definitions/User"
+						}
+					}
+				}],
+				"responses": {
+					"default": {
+						"description": "successful operation"
+					}
+				}
+			}
+		},
+		"/user/login": {
+			"get": {
+				"tags": ["user"],
+				"summary": "Logs user into the system",
+				"description": "",
+				"operationId": "loginUser",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"name": "username",
+					"in": "query",
+					"description": "The user name for login",
+					"required": true,
+					"type": "string"
+				},
+				{
+					"name": "password",
+					"in": "query",
+					"description": "The password for login in clear text",
+					"required": true,
+					"type": "string"
+				}],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"schema": {
+							"type": "string"
+						},
+						"headers": {
+							"X-Rate-Limit": {
+								"type": "integer",
+								"format": "int32",
+								"description": "calls per hour allowed by the user"
+							},
+							"X-Expires-After": {
+								"type": "string",
+								"format": "date-time",
+								"description": "date in UTC when token expires"
+							}
+						}
+					},
+					"400": {
+						"description": "Invalid username/password supplied"
+					}
+				}
+			}
+		},
+		"/user/logout": {
+			"get": {
+				"tags": ["user"],
+				"summary": "Logs out current logged in user session",
+				"description": "",
+				"operationId": "logoutUser",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [],
+				"responses": {
+					"default": {
+						"description": "successful operation"
+					}
+				}
+			}
+		},
+		"/user/{username}": {
+			"get": {
+				"tags": ["user"],
+				"summary": "Get user by user name",
+				"description": "",
+				"operationId": "getUserByName",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"name": "username",
+					"in": "path",
+					"description": "The name that needs to be fetched. Use user1 for testing. ",
+					"required": true,
+					"type": "string"
+				}],
+				"responses": {
+					"200": {
+						"description": "successful operation",
+						"schema": {
+							"$ref": "#/definitions/User"
+						}
+					},
+					"400": {
+						"description": "Invalid username supplied"
+					},
+					"404": {
+						"description": "User not found"
+					}
+				}
+			},
+			"put": {
+				"tags": ["user"],
+				"summary": "Updated user",
+				"description": "This can only be done by the logged in user.",
+				"operationId": "updateUser",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"name": "username",
+					"in": "path",
+					"description": "name that need to be updated",
+					"required": true,
+					"type": "string"
+				},
+				{
+					"in": "body",
+					"name": "body",
+					"description": "Updated user object",
+					"required": true,
+					"schema": {
+						"$ref": "#/definitions/User"
+					}
+				}],
+				"responses": {
+					"400": {
+						"description": "Invalid user supplied"
+					},
+					"404": {
+						"description": "User not found"
+					}
+				}
+			},
+			"delete": {
+				"tags": ["user"],
+				"summary": "Delete user",
+				"description": "This can only be done by the logged in user.",
+				"operationId": "deleteUser",
+				"produces": ["application/xml",
+				"application/json"],
+				"parameters": [{
+					"name": "username",
+					"in": "path",
+					"description": "The name that needs to be deleted",
+					"required": true,
+					"type": "string"
+				}],
+				"responses": {
+					"400": {
+						"description": "Invalid username supplied"
+					},
+					"404": {
+						"description": "User not found"
+					}
+				}
+			}
+		}
+	},
+	"securityDefinitions": {
+		"petstore_auth": {
+			"type": "oauth2",
+			"authorizationUrl": "https://petstore.swagger.io/oauth/authorize",
+			"flow": "implicit",
+			"scopes": {
+				"write:pets": "modify pets in your account",
+				"read:pets": "read your pets"
+			}
+		},
+		"api_key": {
+			"type": "apiKey",
+			"name": "api_key",
+			"in": "header"
+		}
+	},
+	"definitions": {
+		"Order": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "integer",
+					"format": "int64"
+				},
+				"petId": {
+					"type": "integer",
+					"format": "int64"
+				},
+				"quantity": {
+					"type": "integer",
+					"format": "int32"
+				},
+				"shipDate": {
+					"type": "string",
+					"format": "date-time"
+				},
+				"status": {
+					"type": "string",
+					"description": "Order Status",
+					"enum": ["placed",
+					"approved",
+					"delivered"]
+				},
+				"complete": {
+					"type": "boolean",
+					"default": false
+				}
+			},
+			"xml": {
+				"name": "Order"
+			}
+		},
+		"User": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "integer",
+					"format": "int64"
+				},
+				"username": {
+					"type": "string"
+				},
+				"firstName": {
+					"type": "string"
+				},
+				"lastName": {
+					"type": "string"
+				},
+				"email": {
+					"type": "string"
+				},
+				"password": {
+					"type": "string"
+				},
+				"phone": {
+					"type": "string"
+				},
+				"userStatus": {
+					"type": "integer",
+					"format": "int32",
+					"description": "User Status"
+				}
+			},
+			"xml": {
+				"name": "User"
+			}
+		},
+		"Category": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "integer",
+					"format": "int64"
+				},
+				"name": {
+					"type": "string"
+				}
+			},
+			"xml": {
+				"name": "Category"
+			}
+		},
+		"Tag": {
+			"type": "object",
+			"properties": {
+				"id": {
+					"type": "integer",
+					"format": "int64"
+				},
+				"name": {
+					"type": "string"
+				}
+			},
+			"xml": {
+				"name": "Tag"
+			}
+		},
+		"Pet": {
+			"type": "object",
+			"required": ["name",
+			"photoUrls"],
+			"properties": {
+				"id": {
+					"type": "integer",
+					"format": "int64"
+				},
+				"category": {
+					"$ref": "#/definitions/Category"
+				},
+				"name": {
+					"type": "string",
+					"example": "doggie"
+				},
+				"photoUrls": {
+					"type": "array",
+					"xml": {
+						"name": "photoUrl",
+						"wrapped": true
+					},
+					"items": {
+						"type": "string"
+					}
+				},
+				"tags": {
+					"type": "array",
+					"xml": {
+						"name": "tag",
+						"wrapped": true
+					},
+					"items": {
+						"$ref": "#/definitions/Tag"
+					}
+				},
+				"status": {
+					"type": "string",
+					"description": "pet status in the store",
+					"enum": ["available",
+					"pending",
+					"sold"]
+				}
+			},
+			"xml": {
+				"name": "Pet"
+			}
+		},
+		"ApiResponse": {
+			"type": "object",
+			"properties": {
+				"code": {
+					"type": "integer",
+					"format": "int32"
+				},
+				"type": {
+					"type": "string"
+				},
+				"message": {
+					"type": "string"
+				}
+			}
+		}
+	},
+	"externalDocs": {
+		"description": "Find out more about Swagger",
+		"url": "http://swagger.io"
+	}
 }


### PR DESCRIPTION
Problem is in confusing method names, generated for routes with parameters (due to name collisions).

For example, following provider methods are generated for given routes: 
/areas -> GetAreas(...)
/areas/{id} -> GetAreas1(...)

Desired behavior:
/areas -> GetAreas(...)
/areas/{id} -> GetArea(...)

The solution is to singularize route segments, followed by parameters.

Existing unit tests are fixed, integration tests are remained broken (issues not related to PR in both cases). New tests are not created, because of existing issues and because I did not find simple way to test my changes. I am ready to elaborate on tests in case of principal approval of idea.

As for new branch openapi and nuget beta I was not able to test it, because it does not work for me (at least in LinqPad). However I noticed, that logic, related to my changes, basically remained the same.

Thanks.