### PR TITLE
Fix optional headers

### DIFF
--- a/src/SwaggerProvider.DesignTime/OperationCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/OperationCompiler.fs
@@ -135,7 +135,7 @@ type OperationCompiler (schema:SwaggerObject, defCompiler:DefinitionCompiler, ig
                 if param.Required then
                     <@ Array.append %heads [|name, %value|] @>
                 else
-                    let paramDefaultValue = providedParam.DefaultValue
+                    let paramDefaultValue = providedParam.RawDefaultValue
                     let obj = Expr.Coerce(exp, typeof<obj>) |> Expr.Cast<obj>
                     <@ Array.append %heads (if %obj = paramDefaultValue then [||] else [|name, %value|]) @>
 


### PR DESCRIPTION
The current code fails when optional parameters (that map to headers) use the default value.  This cases a null-reference exception when the code tries to convert the default value (likely a null) into a string.