### PR TITLE
Updates ProvidedTypes.fs, ProvidedTypes.fsi

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -279,8 +279,8 @@ NUGET
     YamlDotNet (5.4)
 GITHUB
   remote: fsprojects/FSharp.TypeProviders.SDK
-    src/ProvidedTypes.fs (18459e8b23b44b389dc8f2b8fe444fedf2b47a8c)
-    src/ProvidedTypes.fsi (18459e8b23b44b389dc8f2b8fe444fedf2b47a8c)
+    src/ProvidedTypes.fs (b8727a47dd83d3e88aed8f2100f6712478c64632)
+    src/ProvidedTypes.fsi (b8727a47dd83d3e88aed8f2100f6712478c64632)
   remote: fsharp/FSharp.Data
     src/CommonRuntime/NameUtils.fs (33e6e825bc2978eb9ce6dd880f31d9e60d452699)
     src/CommonRuntime/Pluralizer.fs (33e6e825bc2978eb9ce6dd880f31d9e60d452699)


### PR DESCRIPTION
I've been having issues with Visual Studio running out of memory and crashing while using SwaggerProvider.

I'm not sure, but perhaps it's the same issue as here https://github.com/fsharp/FSharp.Data/issues/1249.
If it's the same issue, it was fixed with https://github.com/fsharp/FSharp.Data/pull/1250 with [an update of ProvidedTypes.fs, ProvidedTypes.fsi](https://github.com/fsharp/FSharp.Data/pull/1250/files#diff-2bfb11ab4230093400363f8d70eab088).

Would we be able to release an updated beta package using the newer TPSDK?

This PR updates it to the [same version currently used by FSharp.Data](https://github.com/fsharp/FSharp.Data/blob/08f351820f8b44c21ac6fb5afb30be0236332d0d/paket.lock#L19).