### PR TITLE
Print pointer in schema parse error message for easier debugging

### DIFF
--- a/src/SwaggerProvider.DesignTime/Provider.OpenApiClient.fs
+++ b/src/SwaggerProvider.DesignTime/Provider.OpenApiClient.fs
@@ -74,7 +74,7 @@ type public OpenApiClientTypeProvider(cfg : TypeProviderConfig) as this =
                         if diagnostic.Errors.Count > 0 then
                             failwithf "Schema parse errors:\n%s"
                                 (diagnostic.Errors
-                                 |> Seq.map (fun e -> e.Message)
+                                 |> Seq.map (fun e -> sprintf "%s @ %s" e.Message e.Pointer)
                                  |> String.concat "\n")
 
                         let defCompiler = DefinitionCompiler(schema, preferNullable)


### PR DESCRIPTION
OpenAPI.NET's reader returns a `OpenApiDiagnostics.Pointer` which has the location of the parsing error. Providing this in the error message will make it easier for users to find out which part of their spec is causing issues.

Before:
```
Schema parse errors:
Data and type mismatch found.
```

After:
```
Schema parse errors:
Data and type mismatch found. @ #/components/schemas/SendSMSRequest/properties/to/example
```