### PR TITLE
Fixed caching

### DIFF
--- a/src/SwaggerProvider.DesignTime/Provider.OpenApiClient.fs
+++ b/src/SwaggerProvider.DesignTime/Provider.OpenApiClient.fs
@@ -52,9 +52,7 @@ type public OpenApiClientTypeProvider(cfg : TypeProviderConfig) as this =
                     |> sprintf "%A"
 
 
-                match Cache.providedTypes.TryRetrieve(cacheKey) with
-                | Some(ty) -> ty
-                | None ->
+                let addCache() =
                     let schemaData =
                         match schemaPathRaw.StartsWith("http", true, null) with
                         | true  ->
@@ -88,8 +86,8 @@ type public OpenApiClientTypeProvider(cfg : TypeProviderConfig) as this =
                     ty.AddMembers tys
                     tempAsm.AddTypes [ty]
 
-                    Cache.providedTypes.Set(cacheKey, ty)
                     ty
+                Cache.providedTypes.GetOrAdd(cacheKey, addCache)
         )
         t
     do

--- a/src/SwaggerProvider.DesignTime/Provider.SwaggerClient.fs
+++ b/src/SwaggerProvider.DesignTime/Provider.SwaggerClient.fs
@@ -67,9 +67,7 @@ type public SwaggerTypeProvider(cfg : TypeProviderConfig) as this =
                     (schemaPathRaw, headersStr, ignoreOperationId, ignoreControllerPrefix, preferNullable, preferAsync)
                     |> sprintf "%A"
 
-                match Cache.providedTypes.TryRetrieve(cacheKey) with
-                | Some(ty) -> ty
-                | None ->
+                let addCache() =
                     let schemaData =
                         match schemaPathRaw.StartsWith("http", true, null) with
                         | true  ->
@@ -106,8 +104,8 @@ type public SwaggerTypeProvider(cfg : TypeProviderConfig) as this =
                     ty.AddMembers tys
                     tempAsm.AddTypes [ty]
 
-                    Cache.providedTypes.Set(cacheKey, ty)
                     ty
+                Cache.providedTypes.GetOrAdd(cacheKey, addCache)
         )
         t
     do


### PR DESCRIPTION
There are 2 issues with the current caching. (Yes, I know it's taken from FSharp.Data.)

1) The cache invalidation is not very good, but as we know it's endless rabbit hole, I'm not fixing it right now.
2) The ConcurrentDictionary is used as normal dictionary, losing the benefit of it being ConcurrentDictionary. That is fixed with this PR. For more details, see: http://www.fssnip.net/7Qr/title/Correct-and-Incorrect-Way-to-Use-ConcurrentDictionary
