### PR TITLE
Just a question...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 *.userprefs
 
 # Build results
-
+/src/Common/AssemblyInfo.fs
 [Dd]ebug/
 [Rr]elease/
 x64/

--- a/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
+++ b/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
@@ -9,6 +9,7 @@
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <OutputPath>..\SwaggerProvider.Runtime\bin\$(Configuration)\typeproviders\fsharp41\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\paket-files\fsharp\FSharp.Data\src\CommonRuntime\Pluralizer.fs">

--- a/src/SwaggerProvider.Runtime/SwaggerProvider.Runtime.fsproj
+++ b/src/SwaggerProvider.Runtime/SwaggerProvider.Runtime.fsproj
@@ -39,18 +39,6 @@
     <MSBuild Projects="..\SwaggerProvider.DesignTime\SwaggerProvider.DesignTime.fsproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=net46" />
   </Target>
   <Target Name="AfterBuild">
-    <CreateItem Include="..\SwaggerProvider.DesignTime\bin\$(Configuration)\netcoreapp3.1\*.dll;..\SwaggerProvider.DesignTime\bin\$(Configuration)\netcoreapp3.1\*.pdb">
-      <Output TaskParameter="Include" ItemName="DesignTimeBinaries1" />
-    </CreateItem>
-    <Copy SourceFiles="@(DesignTimeBinaries1)" DestinationFolder="$(OutputPath)/../typeproviders/fsharp41/netcoreapp3.1" />
-    <CreateItem Include="..\SwaggerProvider.DesignTime\bin\$(Configuration)\net46\*.dll;..\SwaggerProvider.DesignTime\bin\$(Configuration)\net46\*.pdb">
-      <Output TaskParameter="Include" ItemName="DesignTimeBinaries2" />
-    </CreateItem>
-    <Copy SourceFiles="@(DesignTimeBinaries2)" DestinationFolder="$(OutputPath)/../typeproviders/fsharp41/net46" />
-    <CreateItem Include="..\SwaggerProvider.DesignTime\bin\$(Configuration)\netstandard2.0\*.dll;..\SwaggerProvider.DesignTime\bin\$(Configuration)\netstandard2.0\*.pdb">
-      <Output TaskParameter="Include" ItemName="DesignTimeBinaries3" />
-    </CreateItem>
-    <Copy SourceFiles="@(DesignTimeBinaries3)" DestinationFolder="$(OutputPath)/../typeproviders/fsharp41/netstandard2.0" />
   </Target>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Text.Encoding" />


### PR DESCRIPTION
Is there a reason you do first build and then copy?
It would be faster and less code to just build directly to the correct path. Or am I missing something?

Also, the build generated AssemblyInfo.fs have some annoying line-change difference on my machine, so maybe it could be in the .gitignore totally.