### PR TITLE
Cache, yet one more fix...

### DIFF
--- a/src/SwaggerProvider.DesignTime/Provider.OpenApiClient.fs
+++ b/src/SwaggerProvider.DesignTime/Provider.OpenApiClient.fs
@@ -88,7 +88,10 @@ type public OpenApiClientTypeProvider(cfg : TypeProviderConfig) as this =
                     tempAsm.AddTypes [ty]
 
                     ty
-                Cache.providedTypes.GetOrAdd(cacheKey, addCache).Value
+                try Cache.providedTypes.GetOrAdd(cacheKey, addCache).Value
+                with | _ ->
+                  Cache.providedTypes.Remove(cacheKey) |> ignore
+                  Cache.providedTypes.GetOrAdd(cacheKey, addCache).Value
         )
         t
     do


### PR DESCRIPTION
The lazy is working well, however, because the addCache-function may do unreliable network request (fetching the schema) and that can fail, then the exception is stored to the lazy-value and further usages don't actually reset it to retry the operation. So if there is an exception, that has to be removed from the cache.
