### PR TITLE
OpenApiProvider: Dictionary support

### DIFF
--- a/src/SwaggerProvider.DesignTime/v3/DefinitionCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/v3/DefinitionCompiler.fs
@@ -1,4 +1,4 @@
-﻿namespace SwaggerProvider.Internal.v3.Compilers
+namespace SwaggerProvider.Internal.v3.Compilers
 
 open System
 open System.Reflection
@@ -296,6 +296,12 @@ type DefinitionCompiler (schema:OpenApiDocument, provideNullable) as this =
             | _ when schemaObj.Reference <> null && not <| schemaObj.Reference.Id.EndsWith(tyName) ->
                 ns.ReleaseNameReservation tyName
                 compileByPath <| schemaObj.Reference.ReferenceV3
+            | _ when schemaObj.Type = "object" && schemaObj.AdditionalProperties <> null -> // Map ->
+                let elSchema = schemaObj.AdditionalProperties
+                ProvidedTypeBuilder.MakeGenericType(typedefof<Map<string, obj>>, [
+                    typeof<string>
+                    compileBySchema ns tyName elSchema true ns.RegisterType false
+                ])
             | _ when schemaObj.Type = null || schemaObj.Type = "object" -> // Object props ->
                 compileNewObject()
             | _ ->

--- a/src/SwaggerProvider.DesignTime/v3/DefinitionCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/v3/DefinitionCompiler.fs
@@ -296,7 +296,7 @@ type DefinitionCompiler (schema:OpenApiDocument, provideNullable) as this =
             | _ when schemaObj.Reference <> null && not <| schemaObj.Reference.Id.EndsWith(tyName) ->
                 ns.ReleaseNameReservation tyName
                 compileByPath <| schemaObj.Reference.ReferenceV3
-            | _ when schemaObj.Type = "object" && schemaObj.AdditionalProperties <> null -> // Map ->
+            | _ when schemaObj.Type = "object" && schemaObj.AdditionalProperties <> null -> // Dictionary ->
                 let elSchema = schemaObj.AdditionalProperties
                 ProvidedTypeBuilder.MakeGenericType(typedefof<Map<string, obj>>, [
                     typeof<string>

--- a/tests/SwaggerProvider.ProviderTests/Schemas/v3/issue173.json
+++ b/tests/SwaggerProvider.ProviderTests/Schemas/v3/issue173.json
@@ -1,0 +1,17167 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "OdhApi Tourism .Net Core",
+      "description": "ODH Tourism Api based on .Net Core with PostgreSQL",
+      "termsOfService": "https://opendatahub.readthedocs.io/en/latest/",
+      "contact": {
+        "name": "Open Data Hub Team",
+        "url": "https://opendatahub.bz.it/",
+        "email": "info@opendatahub.bz.it"
+      },
+      "version": "v1"
+    },
+    "servers": [
+      {
+        "url": "https://api.tourism.testingmachine.eu"
+      }
+    ],
+    "paths": {
+      "/api/Accommodation": {
+        "get": {
+          "tags": [
+            "Accommodation"
+          ],
+          "summary": "GET Accommodation List",
+          "operationId": "AccommodationList",
+          "parameters": [
+            {
+              "name": "pagenumber",
+              "in": "query",
+              "description": "Pagenumber, (default:1)",
+              "schema": {
+                "type": "integer",
+                "description": "Pagenumber, (default:1)",
+                "format": "int32",
+                "default": 1
+              }
+            },
+            {
+              "name": "pagesize",
+              "in": "query",
+              "description": "Elements per Page (If availabilitycheck set, pagesize has no effect all Accommodations are returned), (default:10)",
+              "schema": {
+                "type": "integer",
+                "description": "Elements per Page (If availabilitycheck set, pagesize has no effect all Accommodations are returned), (default:10)",
+                "format": "int32",
+                "default": 10
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, 'null' disables Random Sorting, (default:null)",
+              "schema": {
+                "type": "string",
+                "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, 'null' disables Random Sorting, (default:null)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "categoryfilter",
+              "in": "query",
+              "description": "Categoryfilter (BITMASK values: 1 = (not categorized), 2 = (1star), 4 = (1flower), 8 = (1sun), 14 = (1star/1flower/1sun), 16 = (2stars), 32 = (2flowers), 64 = (2suns), 112 = (2stars/2flowers/2suns), 128 = (3stars), 256 = (3flowers), 512 = (3suns), 1024 = (3sstars), 1920 = (3stars/3flowers/3suns/3sstars), 2048 = (4stars), 4096 = (4flowers), 8192 = (4suns), 16384 = (4sstars), 30720 = (4stars/4flowers/4suns/4sstars), 32768 = (5stars), 65536 = (5flowers), 131072 = (5suns), 229376 = (5stars/5flowers/5suns), 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Categoryfilter (BITMASK values: 1 = (not categorized), 2 = (1star), 4 = (1flower), 8 = (1sun), 14 = (1star/1flower/1sun), 16 = (2stars), 32 = (2flowers), 64 = (2suns), 112 = (2stars/2flowers/2suns), 128 = (3stars), 256 = (3flowers), 512 = (3suns), 1024 = (3sstars), 1920 = (3stars/3flowers/3suns/3sstars), 2048 = (4stars), 4096 = (4flowers), 8192 = (4suns), 16384 = (4sstars), 30720 = (4stars/4flowers/4suns/4sstars), 32768 = (5stars), 65536 = (5flowers), 131072 = (5suns), 229376 = (5stars/5flowers/5suns), 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "typefilter",
+              "in": "query",
+              "description": "Typefilter (BITMASK values: 1 = (HotelPension), 2 = (BedBreakfast), 4 = (Farm), 8 = (Camping), 16 = (Youth), 32 = (Mountain), 64 = (Apartment), 128 = (Not defined),'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Typefilter (BITMASK values: 1 = (HotelPension), 2 = (BedBreakfast), 4 = (Farm), 8 = (Camping), 16 = (Youth), 32 = (Mountain), 64 = (Apartment), 128 = (Not defined),'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "boardfilter",
+              "in": "query",
+              "description": "Boardfilter (BITMASK values: 0 = (all boards), 1 = (without board), 2 = (breakfast), 4 = (half board), 8 = (full board), 16 = (All inclusive), 'null' = No Filter), (default:'0')",
+              "schema": {
+                "type": "string",
+                "description": "Boardfilter (BITMASK values: 0 = (all boards), 1 = (without board), 2 = (breakfast), 4 = (half board), 8 = (full board), 16 = (All inclusive), 'null' = No Filter), (default:'0')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "featurefilter",
+              "in": "query",
+              "description": "FeatureFilter (BITMASK values: 1 = (Group-friendly), 2 = (Meeting rooms), 4 = (Swimming pool), 8 = (Sauna), 16 = (Garage), 32 = (Pick-up service), 64 = (WLAN), 128 = (Barrier-free), 256 = (Special menus for allergy sufferers), 512 = (Pets welcome), 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "FeatureFilter (BITMASK values: 1 = (Group-friendly), 2 = (Meeting rooms), 4 = (Swimming pool), 8 = (Sauna), 16 = (Garage), 32 = (Pick-up service), 64 = (WLAN), 128 = (Barrier-free), 256 = (Special menus for allergy sufferers), 512 = (Pets welcome), 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "featureidfilter",
+              "in": "query",
+              "description": "Feature Id Filter, filter over ALL Features vailable (Separator ',' List of Feature IDs, 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Feature Id Filter, filter over ALL Features vailable (Separator ',' List of Feature IDs, 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "themefilter",
+              "in": "query",
+              "description": "Themefilter (BITMASK values: 1 = (Gourmet), 2 = (At altitude), 4 = (Regional wellness offerings), 8 = (on the wheels), 16 = (With family), 32 = (Hiking), 64 = (In the vineyards), 128 = (Urban vibe), 256 = (At the ski resort), 512 = (Mediterranean), 1024 = (In the Dolomites), 2048 = (Alpine), 4096 = (Small and charming), 8192 = (Huts and mountain inns), 16384 = (Rural way of life), 32768 = (Balance), 65536 = (Christmas markets), 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Themefilter (BITMASK values: 1 = (Gourmet), 2 = (At altitude), 4 = (Regional wellness offerings), 8 = (on the wheels), 16 = (With family), 32 = (Hiking), 64 = (In the vineyards), 128 = (Urban vibe), 256 = (At the ski resort), 512 = (Mediterranean), 1024 = (In the Dolomites), 2048 = (Alpine), 4096 = (Small and charming), 8192 = (Huts and mountain inns), 16384 = (Rural way of life), 32768 = (Balance), 65536 = (Christmas markets), 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "badgefilter",
+              "in": "query",
+              "description": "BadgeFilter (BITMASK values: 1 = (Belvita Wellness Hotel), 2 = (Familyhotel), 4 = (Bikehotel), 8 = (Red Rooster Farm), 16 = (Barrier free certificated), 32 = (Vitalpina Hiking Hotel), 64 = (Private Rooms in South Tyrol), 128 = (Vinum Hotels), 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "BadgeFilter (BITMASK values: 1 = (Belvita Wellness Hotel), 2 = (Familyhotel), 4 = (Bikehotel), 8 = (Red Rooster Farm), 16 = (Barrier free certificated), 32 = (Vitalpina Hiking Hotel), 64 = (Private Rooms in South Tyrol), 128 = (Vinum Hotels), 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "idfilter",
+              "in": "query",
+              "description": "IDFilter (Separator ',' List of Accommodation IDs, 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "IDFilter (Separator ',' List of Accommodation IDs, 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "locfilter",
+              "in": "query",
+              "description": "Locfilter (Separator ',' possible values: reg + REGIONID = (Filter by Region), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction), 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Locfilter (Separator ',' possible values: reg + REGIONID = (Filter by Region), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction), 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "altitudefilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhtagfilter",
+              "in": "query",
+              "description": "ODHTag Filter (refers to Array SmgTags) (String, Separator ',' more ODHTags possible, 'null' = No Filter, available ODHTags reference to 'api/ODHTag?validforentity=accommodation'), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "ODHTag Filter (refers to Array SmgTags) (String, Separator ',' more ODHTags possible, 'null' = No Filter, available ODHTags reference to 'api/ODHTag?validforentity=accommodation'), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhactive",
+              "in": "query",
+              "description": "ODHActive Filter (refers to field SmgActive) (possible Values: 'null' Displays all Accommodations, 'true' only ODH Active Accommodations, 'false' only ODH Disabled Accommodations, (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "ODHActive Filter (refers to field SmgActive) (possible Values: 'null' Displays all Accommodations, 'true' only ODH Active Accommodations, 'false' only ODH Disabled Accommodations, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "active",
+              "in": "query",
+              "description": "TIC Active Filter (possible Values: 'null' Displays all Accommodations, 'true' only TIC Active Accommodations, 'false' only TIC Disabled Accommodations, (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "TIC Active Filter (possible Values: 'null' Displays all Accommodations, 'true' only TIC Active Accommodations, 'false' only TIC Disabled Accommodations, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "bookablefilter",
+              "in": "query",
+              "schema": {
+                "type": "boolean",
+                "nullable": true
+              }
+            },
+            {
+              "name": "arrival",
+              "in": "query",
+              "description": "Arrival Date (yyyy-MM-dd) REQUIRED, (default:'Today')",
+              "schema": {
+                "type": "string",
+                "description": "Arrival Date (yyyy-MM-dd) REQUIRED, (default:'Today')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "departure",
+              "in": "query",
+              "description": "Departure Date (yyyy-MM-dd) REQUIRED, (default:'Tomorrow')",
+              "schema": {
+                "type": "string",
+                "description": "Departure Date (yyyy-MM-dd) REQUIRED, (default:'Tomorrow')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "roominfo",
+              "in": "query",
+              "description": "Roominfo Filter REQUIRED (Splitter for Rooms '|' Splitter for Persons Ages ',') (Room Types: 0=notprovided, 1=room, 2=apartment, 4=pitch/tent(onlyLTS), 8=dorm(onlyLTS)) possible Values Example 1-18,10|1-18 = 2 Rooms, Room 1 for 2 person Age 18 and Age 10, Room 2 for 1 Person Age 18), (default:'1-18,18')",
+              "schema": {
+                "type": "string",
+                "description": "Roominfo Filter REQUIRED (Splitter for Rooms '|' Splitter for Persons Ages ',') (Room Types: 0=notprovided, 1=room, 2=apartment, 4=pitch/tent(onlyLTS), 8=dorm(onlyLTS)) possible Values Example 1-18,10|1-18 = 2 Rooms, Room 1 for 2 person Age 18 and Age 10, Room 2 for 1 Person Age 18), (default:'1-18,18')",
+                "default": "1-18,18",
+                "nullable": true
+              }
+            },
+            {
+              "name": "bokfilter",
+              "in": "query",
+              "description": "Booking Channels Filter REQUIRED (Separator ',' possible values: hgv = (Booking Südtirol), htl = (Hotel.de), exp = (Expedia), bok = (Booking.com), lts = (LTS Availability check)), (default:'hgv')",
+              "schema": {
+                "type": "string",
+                "description": "Booking Channels Filter REQUIRED (Separator ',' possible values: hgv = (Booking Südtirol), htl = (Hotel.de), exp = (Expedia), bok = (Booking.com), lts = (LTS Availability check)), (default:'hgv')",
+                "default": "hgv",
+                "nullable": true
+              }
+            },
+            {
+              "name": "source",
+              "in": "query",
+              "description": "Source for MSS availability check, (default:'sinfo')",
+              "schema": {
+                "type": "string",
+                "description": "Source for MSS availability check, (default:'sinfo')",
+                "default": "sinfo",
+                "nullable": true
+              }
+            },
+            {
+              "name": "availabilitychecklanguage",
+              "in": "query",
+              "description": "Language of the Availability Response (possible values: 'de','it','en'), (default:'en')",
+              "schema": {
+                "type": "string",
+                "description": "Language of the Availability Response (possible values: 'de','it','en'), (default:'en')",
+                "default": "en",
+                "nullable": true
+              }
+            },
+            {
+              "name": "availabilitycheck",
+              "in": "query",
+              "description": "Availability Check enabled/disabled (possible Values: 'true', 'false), (default Value: 'false') NOT AVAILABLE AS OPEN DATA",
+              "schema": {
+                "type": "boolean",
+                "description": "Availability Check enabled/disabled (possible Values: 'true', 'false), (default Value: 'false') NOT AVAILABLE AS OPEN DATA",
+                "nullable": true
+              }
+            },
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "updatefrom",
+              "in": "query",
+              "description": "Date from Format (yyyy-MM-dd) (all GBActivityPoi with LastChange >= datefrom are passed), (default: null)",
+              "schema": {
+                "type": "string",
+                "description": "Date from Format (yyyy-MM-dd) (all GBActivityPoi with LastChange >= datefrom are passed), (default: null)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "description": "String to search for, Title in all languages are searched, (default: null)",
+              "schema": {
+                "type": "string",
+                "description": "String to search for, Title in all languages are searched, (default: null)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/AccommodationJsonResult"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/AccommodationJsonResult"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/AccommodationJsonResult"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/AccommodationJsonResult"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Accommodation/{id}": {
+        "get": {
+          "tags": [
+            "Accommodation"
+          ],
+          "summary": "GET Accommodation Single",
+          "operationId": "SingleAccommodation",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the Accommodation",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the Accommodation",
+                "nullable": true
+              }
+            },
+            {
+              "name": "idsource",
+              "in": "query",
+              "description": "ID Source Filter (possible values:'lts','hgv'), (default:'lts')",
+              "schema": {
+                "type": "string",
+                "description": "ID Source Filter (possible values:'lts','hgv'), (default:'lts')",
+                "default": "lts",
+                "nullable": true
+              }
+            },
+            {
+              "name": "availabilitychecklanguage",
+              "in": "query",
+              "description": "Language of the Availability Response (possible values: 'de','it','en'), (default:'de')",
+              "schema": {
+                "type": "string",
+                "description": "Language of the Availability Response (possible values: 'de','it','en'), (default:'de')",
+                "default": "en",
+                "nullable": true
+              }
+            },
+            {
+              "name": "boardfilter",
+              "in": "query",
+              "description": "Boardfilter (BITMASK values: 0 = (all boards), 1 = (without board), 2 = (breakfast), 4 = (half board), 8 = (full board), 16 = (All inclusive), 'null' = No Filter), (default:'0')",
+              "schema": {
+                "type": "string",
+                "description": "Boardfilter (BITMASK values: 0 = (all boards), 1 = (without board), 2 = (breakfast), 4 = (half board), 8 = (full board), 16 = (All inclusive), 'null' = No Filter), (default:'0')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "arrival",
+              "in": "query",
+              "description": "Arrival Date (yyyy-MM-dd) REQUIRED, (default:'Today')",
+              "schema": {
+                "type": "string",
+                "description": "Arrival Date (yyyy-MM-dd) REQUIRED, (default:'Today')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "departure",
+              "in": "query",
+              "description": "Departure Date (yyyy-MM-dd) REQUIRED, (default:'Tomorrow')",
+              "schema": {
+                "type": "string",
+                "description": "Departure Date (yyyy-MM-dd) REQUIRED, (default:'Tomorrow')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "roominfo",
+              "in": "query",
+              "description": "Roominfo Filter REQUIRED (Splitter for Rooms '|' Splitter for Persons Ages ',') (Room Types: 0=notprovided, 1=room, 2=apartment, 4=pitch/tent(onlyLTS), 8=dorm(onlyLTS)) possible Values Example 1-18,10|1-18 = 2 Rooms, Room 1 for 2 person Age 18 and Age 10, Room 2 for 1 Person Age 18), (default:'1-18,18')",
+              "schema": {
+                "type": "string",
+                "description": "Roominfo Filter REQUIRED (Splitter for Rooms '|' Splitter for Persons Ages ',') (Room Types: 0=notprovided, 1=room, 2=apartment, 4=pitch/tent(onlyLTS), 8=dorm(onlyLTS)) possible Values Example 1-18,10|1-18 = 2 Rooms, Room 1 for 2 person Age 18 and Age 10, Room 2 for 1 Person Age 18), (default:'1-18,18')",
+                "default": "1-18,18",
+                "nullable": true
+              }
+            },
+            {
+              "name": "bokfilter",
+              "in": "query",
+              "description": "Booking Channels Filter REQUIRED (Separator ',' possible values: hgv = (Booking Südtirol), htl = (Hotel.de), exp = (Expedia), bok = (Booking.com), lts = (LTS Availability check)), (default:'hgv')",
+              "schema": {
+                "type": "string",
+                "description": "Booking Channels Filter REQUIRED (Separator ',' possible values: hgv = (Booking Südtirol), htl = (Hotel.de), exp = (Expedia), bok = (Booking.com), lts = (LTS Availability check)), (default:'hgv')",
+                "default": "hgv",
+                "nullable": true
+              }
+            },
+            {
+              "name": "source",
+              "in": "query",
+              "description": "Source for MSS availability check, (default:'sinfo')",
+              "schema": {
+                "type": "string",
+                "description": "Source for MSS availability check, (default:'sinfo')",
+                "default": "sinfo",
+                "nullable": true
+              }
+            },
+            {
+              "name": "availabilitycheck",
+              "in": "query",
+              "description": "Availability Check enabled/disabled (possible Values: 'true', 'false), (default Value: 'false') NOT AVAILABLE AS OPEN DATA",
+              "schema": {
+                "type": "boolean",
+                "description": "Availability Check enabled/disabled (possible Values: 'true', 'false), (default Value: 'false') NOT AVAILABLE AS OPEN DATA",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Accommodation"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Accommodation"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Accommodation"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Accommodation"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/AccommodationTypes": {
+        "get": {
+          "tags": [
+            "Accommodation"
+          ],
+          "summary": "GET Accommodation Types List",
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ArticleTypes"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ArticleTypes"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ArticleTypes"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ArticleTypes"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/AccommodationTypes/{id}": {
+        "get": {
+          "tags": [
+            "Accommodation"
+          ],
+          "summary": "GET Accommodation Types Single",
+          "operationId": "SingleAccommodationTypes",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the AccommodationType",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the AccommodationType",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ArticleTypes"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ArticleTypes"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ArticleTypes"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ArticleTypes"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/AccommodationFeatures": {
+        "get": {
+          "tags": [
+            "Accommodation"
+          ],
+          "summary": "GET Accommodation Feature List (LTS Features)",
+          "parameters": [
+            {
+              "name": "source",
+              "in": "query",
+              "description": "IF source = \"lts\" the Features list is returned in XML Format directly from LTS, (default: blank)",
+              "schema": {
+                "type": "string",
+                "description": "IF source = \"lts\" the Features list is returned in XML Format directly from LTS, (default: blank)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/AccoFeature"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/AccoFeature"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/AccoFeature"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/AccoFeature"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/AccommodationFeatures/{id}": {
+        "get": {
+          "tags": [
+            "Accommodation"
+          ],
+          "summary": "GET Accommodation Feature Single (LTS Features)",
+          "operationId": "SingleAccommodationFeatures",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the AccommodationFeature",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the AccommodationFeature",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/AccoFeature"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/AccoFeature"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/AccoFeature"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/AccoFeature"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/AccommodationAvailable": {
+        "post": {
+          "tags": [
+            "Accommodation"
+          ],
+          "summary": "POST Available Accommodations HGV(Booking Suedtirol MSS) / LTS on posted IDs",
+          "parameters": [
+            {
+              "name": "availabilitychecklanguage",
+              "in": "query",
+              "description": "Language of the Availability Response",
+              "schema": {
+                "type": "string",
+                "description": "Language of the Availability Response",
+                "default": "en",
+                "nullable": true
+              }
+            },
+            {
+              "name": "boardfilter",
+              "in": "query",
+              "description": "Boardfilter (BITMASK values: 0 = (all boards), 1 = (without board), 2 = (breakfast), 4 = (half board), 8 = (full board), 16 = (All inclusive), 'null' = No Filter)",
+              "schema": {
+                "type": "string",
+                "description": "Boardfilter (BITMASK values: 0 = (all boards), 1 = (without board), 2 = (breakfast), 4 = (half board), 8 = (full board), 16 = (All inclusive), 'null' = No Filter)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "arrival",
+              "in": "query",
+              "description": "Arrival Date (yyyy-MM-dd) REQUIRED",
+              "schema": {
+                "type": "string",
+                "description": "Arrival Date (yyyy-MM-dd) REQUIRED",
+                "nullable": true
+              }
+            },
+            {
+              "name": "departure",
+              "in": "query",
+              "description": "Departure Date (yyyy-MM-dd) REQUIRED",
+              "schema": {
+                "type": "string",
+                "description": "Departure Date (yyyy-MM-dd) REQUIRED",
+                "nullable": true
+              }
+            },
+            {
+              "name": "roominfo",
+              "in": "query",
+              "description": "Roominfo Filter REQUIRED (Splitter for Rooms '|' Splitter for Persons Ages ',') (Room Types: 0=notprovided, 1=room, 2=apartment, 4=pitch/tent(onlyLTS), 8=dorm(onlyLTS)) possible Values Example 1-18,10|1-18 = 2 Rooms, Room 1 for 2 person Age 18 and Age 10, Room 2 for 1 Person Age 18), (default:'1-18,18')",
+              "schema": {
+                "type": "string",
+                "description": "Roominfo Filter REQUIRED (Splitter for Rooms '|' Splitter for Persons Ages ',') (Room Types: 0=notprovided, 1=room, 2=apartment, 4=pitch/tent(onlyLTS), 8=dorm(onlyLTS)) possible Values Example 1-18,10|1-18 = 2 Rooms, Room 1 for 2 person Age 18 and Age 10, Room 2 for 1 Person Age 18), (default:'1-18,18')",
+                "default": "1-18,18",
+                "nullable": true
+              }
+            },
+            {
+              "name": "bokfilter",
+              "in": "query",
+              "description": "Booking Channels Filter (Separator ',' possible values: hgv = (Booking Südtirol), htl = (Hotel.de), exp = (Expedia), bok = (Booking.com), lts = (LTS Availability check), (default:hgv)) REQUIRED",
+              "schema": {
+                "type": "string",
+                "description": "Booking Channels Filter (Separator ',' possible values: hgv = (Booking Südtirol), htl = (Hotel.de), exp = (Expedia), bok = (Booking.com), lts = (LTS Availability check), (default:hgv)) REQUIRED",
+                "default": "hgv",
+                "nullable": true
+              }
+            },
+            {
+              "name": "source",
+              "in": "query",
+              "description": "Source of the Requester (possible value: 'sinfo' = Suedtirol.info, 'sbalance' = Südtirol Balance) REQUIRED",
+              "schema": {
+                "type": "string",
+                "description": "Source of the Requester (possible value: 'sinfo' = Suedtirol.info, 'sbalance' = Südtirol Balance) REQUIRED",
+                "default": "sinfo",
+                "nullable": true
+              }
+            },
+            {
+              "name": "detail",
+              "in": "query",
+              "description": "Include Offer Details (Boolean, 1 = full Details)",
+              "schema": {
+                "type": "integer",
+                "description": "Include Offer Details (Boolean, 1 = full Details)",
+                "format": "int32",
+                "default": 0
+              }
+            },
+            {
+              "name": "withoutmssids",
+              "in": "query",
+              "description": "Search over all bookable Accommodations on HGV MSS (No Ids have to be provided as Post Data) (default: false)",
+              "schema": {
+                "type": "boolean",
+                "description": "Search over all bookable Accommodations on HGV MSS (No Ids have to be provided as Post Data) (default: false)",
+                "default": false
+              }
+            },
+            {
+              "name": "withoutlcsids",
+              "in": "query",
+              "description": "Search over all Accommodations on LTS (No Ids have to be provided as Post Data) (default: false)",
+              "schema": {
+                "type": "boolean",
+                "description": "Search over all Accommodations on LTS (No Ids have to be provided as Post Data) (default: false)",
+                "default": false
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Posted Accommodation IDs (Separated by ,)",
+            "content": {
+              "application/json-patch+json": {
+                "schema": {
+                  "type": "string",
+                  "description": "Posted Accommodation IDs (Separated by ,)",
+                  "nullable": true
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "description": "Posted Accommodation IDs (Separated by ,)",
+                  "nullable": true
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "description": "Posted Accommodation IDs (Separated by ,)",
+                  "nullable": true
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "type": "string",
+                  "description": "Posted Accommodation IDs (Separated by ,)",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Accommodation"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Accommodation"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Accommodation"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Accommodation"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/AvailabilityCheck": {
+        "post": {
+          "tags": [
+            "Accommodation"
+          ],
+          "summary": "POST Available Accommodations HGV(Booking Suedtirol MSS) / LTS on posted IDs only Availability Response NOT AVAILABLE AS OPEN DATA",
+          "parameters": [
+            {
+              "name": "availabilitychecklanguage",
+              "in": "query",
+              "description": "Language of the Availability Response",
+              "schema": {
+                "type": "string",
+                "description": "Language of the Availability Response",
+                "default": "en",
+                "nullable": true
+              }
+            },
+            {
+              "name": "boardfilter",
+              "in": "query",
+              "description": "Boardfilter (BITMASK values: 0 = (all boards), 1 = (without board), 2 = (breakfast), 4 = (half board), 8 = (full board), 16 = (All inclusive), 'null' = No Filter)",
+              "schema": {
+                "type": "string",
+                "description": "Boardfilter (BITMASK values: 0 = (all boards), 1 = (without board), 2 = (breakfast), 4 = (half board), 8 = (full board), 16 = (All inclusive), 'null' = No Filter)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "arrival",
+              "in": "query",
+              "description": "Arrival Date (yyyy-MM-dd) REQUIRED",
+              "schema": {
+                "type": "string",
+                "description": "Arrival Date (yyyy-MM-dd) REQUIRED",
+                "nullable": true
+              }
+            },
+            {
+              "name": "departure",
+              "in": "query",
+              "description": "Departure Date (yyyy-MM-dd) REQUIRED",
+              "schema": {
+                "type": "string",
+                "description": "Departure Date (yyyy-MM-dd) REQUIRED",
+                "nullable": true
+              }
+            },
+            {
+              "name": "roominfo",
+              "in": "query",
+              "description": "Roominfo Filter REQUIRED (Splitter for Rooms '|' Splitter for Persons Ages ',') (Room Types: 0=notprovided, 1=room, 2=apartment, 4=pitch/tent(onlyLTS), 8=dorm(onlyLTS)) possible Values Example 1-18,10|1-18 = 2 Rooms, Room 1 for 2 person Age 18 and Age 10, Room 2 for 1 Person Age 18), (default:'1-18,18')",
+              "schema": {
+                "type": "string",
+                "description": "Roominfo Filter REQUIRED (Splitter for Rooms '|' Splitter for Persons Ages ',') (Room Types: 0=notprovided, 1=room, 2=apartment, 4=pitch/tent(onlyLTS), 8=dorm(onlyLTS)) possible Values Example 1-18,10|1-18 = 2 Rooms, Room 1 for 2 person Age 18 and Age 10, Room 2 for 1 Person Age 18), (default:'1-18,18')",
+                "default": "1-18,18",
+                "nullable": true
+              }
+            },
+            {
+              "name": "bokfilter",
+              "in": "query",
+              "description": "Booking Channels Filter (Separator ',' possible values: hgv = (Booking Südtirol), htl = (Hotel.de), exp = (Expedia), bok = (Booking.com), lts = (LTS Availability check), (default:hgv)) REQUIRED",
+              "schema": {
+                "type": "string",
+                "description": "Booking Channels Filter (Separator ',' possible values: hgv = (Booking Südtirol), htl = (Hotel.de), exp = (Expedia), bok = (Booking.com), lts = (LTS Availability check), (default:hgv)) REQUIRED",
+                "default": "hgv",
+                "nullable": true
+              }
+            },
+            {
+              "name": "source",
+              "in": "query",
+              "description": "Source of the Requester (possible value: 'sinfo' = Suedtirol.info, 'sbalance' = Südtirol Balance) REQUIRED",
+              "schema": {
+                "type": "string",
+                "description": "Source of the Requester (possible value: 'sinfo' = Suedtirol.info, 'sbalance' = Südtirol Balance) REQUIRED",
+                "default": "sinfo",
+                "nullable": true
+              }
+            },
+            {
+              "name": "detail",
+              "in": "query",
+              "description": "Include Offer Details (Boolean, 1 = full Details)",
+              "schema": {
+                "type": "integer",
+                "description": "Include Offer Details (Boolean, 1 = full Details)",
+                "format": "int32",
+                "default": 0
+              }
+            },
+            {
+              "name": "withoutmssids",
+              "in": "query",
+              "description": "Search over all bookable Accommodations on HGV MSS (No Ids have to be provided as Post Data) (default: false)",
+              "schema": {
+                "type": "boolean",
+                "description": "Search over all bookable Accommodations on HGV MSS (No Ids have to be provided as Post Data) (default: false)",
+                "default": false
+              }
+            },
+            {
+              "name": "withoutlcsids",
+              "in": "query",
+              "description": "Search over all Accommodations on LTS (No Ids have to be provided as Post Data) (default: false)",
+              "schema": {
+                "type": "boolean",
+                "description": "Search over all Accommodations on LTS (No Ids have to be provided as Post Data) (default: false)",
+                "default": false
+              }
+            }
+          ],
+          "requestBody": {
+            "description": "Posted Accommodation IDs (Separated by ,)",
+            "content": {
+              "application/json-patch+json": {
+                "schema": {
+                  "type": "string",
+                  "description": "Posted Accommodation IDs (Separated by ,)",
+                  "nullable": true
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "description": "Posted Accommodation IDs (Separated by ,)",
+                  "nullable": true
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "description": "Posted Accommodation IDs (Separated by ,)",
+                  "nullable": true
+                }
+              },
+              "application/*+json": {
+                "schema": {
+                  "type": "string",
+                  "description": "Posted Accommodation IDs (Separated by ,)",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/MssResponseShort"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/MssResponseShort"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/MssResponseShort"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/MssResponseShort"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Activity": {
+        "get": {
+          "tags": [
+            "Activity"
+          ],
+          "summary": "GET Activity List",
+          "parameters": [
+            {
+              "name": "language",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "pagenumber",
+              "in": "query",
+              "description": "Pagenumber, (default:1)",
+              "schema": {
+                "type": "integer",
+                "description": "Pagenumber, (default:1)",
+                "format": "int32",
+                "default": 1
+              }
+            },
+            {
+              "name": "pagesize",
+              "in": "query",
+              "description": "Elements per Page, (default:10)",
+              "schema": {
+                "type": "integer",
+                "description": "Elements per Page, (default:10)",
+                "format": "int32",
+                "default": 10
+              }
+            },
+            {
+              "name": "activitytype",
+              "in": "query",
+              "description": "Type of the Activity ('null' = Filter disabled, possible values: BITMASK: 'Mountains = 1','Cycling = 2','Local tours = 4','Horses = 8','Hiking = 16','Running and fitness = 32','Cross-country ski-track = 64','Tobbogan run = 128','Slopes = 256','Lifts = 512'), (default:'1023' == ALL), REFERENCE TO: GET /api/ActivityTypes",
+              "schema": {
+                "type": "string",
+                "description": "Type of the Activity ('null' = Filter disabled, possible values: BITMASK: 'Mountains = 1','Cycling = 2','Local tours = 4','Horses = 8','Hiking = 16','Running and fitness = 32','Cross-country ski-track = 64','Tobbogan run = 128','Slopes = 256','Lifts = 512'), (default:'1023' == ALL), REFERENCE TO: GET /api/ActivityTypes",
+                "default": "1023",
+                "nullable": true
+              }
+            },
+            {
+              "name": "subtype",
+              "in": "query",
+              "description": "Subtype of the Activity (BITMASK Filter = available SubTypes depends on the selected Activity Type), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Subtype of the Activity (BITMASK Filter = available SubTypes depends on the selected Activity Type), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "idlist",
+              "in": "query",
+              "description": "IDFilter (Separator ',' List of Activity IDs), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "IDFilter (Separator ',' List of Activity IDs), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "locfilter",
+              "in": "query",
+              "description": "Locfilter (Separator ',' possible values: reg + REGIONID = (Filter by Region), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction)), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Locfilter (Separator ',' possible values: reg + REGIONID = (Filter by Region), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction)), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "areafilter",
+              "in": "query",
+              "description": "AreaFilter (Separator ',' IDList of AreaIDs separated by ','), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "AreaFilter (Separator ',' IDList of AreaIDs separated by ','), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "distancefilter",
+              "in": "query",
+              "description": "Distance Range Filter (Separator ',' example Value: 15,40 Distance from 15 up to 40 Km), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Distance Range Filter (Separator ',' example Value: 15,40 Distance from 15 up to 40 Km), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "altitudefilter",
+              "in": "query",
+              "description": "Altitude Range Filter (Separator ',' example Value: 500,1000 Altitude from 500 up to 1000 metres), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Altitude Range Filter (Separator ',' example Value: 500,1000 Altitude from 500 up to 1000 metres), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "durationfilter",
+              "in": "query",
+              "description": "Duration Range Filter (Separator ',' example Value: 1,3 Duration from 1 to 3 hours), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Duration Range Filter (Separator ',' example Value: 1,3 Duration from 1 to 3 hours), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "highlight",
+              "in": "query",
+              "description": "Hightlight Filter (possible values: 'false' = only Activities with Highlight false, 'true' = only Activities with Highlight true), (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "Hightlight Filter (possible values: 'false' = only Activities with Highlight false, 'true' = only Activities with Highlight true), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "difficultyfilter",
+              "in": "query",
+              "description": "Difficulty Filter (possible values: '1' = easy, '2' = medium, '3' = difficult), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Difficulty Filter (possible values: '1' = easy, '2' = medium, '3' = difficult), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhtagfilter",
+              "in": "query",
+              "description": "Taglist Filter (String, Separator ',' more Tags possible, available Tags reference to 'api/ODHTag?validforentity=activity'), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Taglist Filter (String, Separator ',' more Tags possible, available Tags reference to 'api/ODHTag?validforentity=activity'), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "active",
+              "in": "query",
+              "description": "Active Activities Filter (possible Values: 'true' only Active Activities, 'false' only Disabled Activities",
+              "schema": {
+                "type": "boolean",
+                "description": "Active Activities Filter (possible Values: 'true' only Active Activities, 'false' only Disabled Activities",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhactive",
+              "in": "query",
+              "description": "odhactive (Published) Activities Filter (possible Values: 'true' only published Activities, 'false' only not published Activities, (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "odhactive (Published) Activities Filter (possible Values: 'true' only published Activities, 'false' only not published Activities, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "lastchange",
+              "in": "query",
+              "description": "Returns data changed after this date Format (yyyy-MM-dd), (default: 'null')",
+              "schema": {
+                "type": "string",
+                "description": "Returns data changed after this date Format (yyyy-MM-dd), (default: 'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, 'null' disables Random Sorting, (default:null)",
+              "schema": {
+                "type": "string",
+                "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, 'null' disables Random Sorting, (default:null)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSActivityJsonResult"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSActivityJsonResult"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSActivityJsonResult"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSActivityJsonResult"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Activity/{id}": {
+        "get": {
+          "tags": [
+            "Activity"
+          ],
+          "summary": "GET Activity Single",
+          "operationId": "SingleActivity",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the Activity",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the Activity",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSActivity"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSActivity"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSActivity"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSActivity"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/ActivityTypes": {
+        "get": {
+          "tags": [
+            "Activity"
+          ],
+          "summary": "GET Activity Types List",
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ActivityTypes"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ActivityTypes"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ActivityTypes"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ActivityTypes"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/ActivityTypes/{id}": {
+        "get": {
+          "tags": [
+            "Activity"
+          ],
+          "summary": "GET Activity Types Single",
+          "operationId": "SingleActivityTypes",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ActivityTypes"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ActivityTypes"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ActivityTypes"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ActivityTypes"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Article": {
+        "get": {
+          "tags": [
+            "Article"
+          ],
+          "summary": "GET Article List",
+          "parameters": [
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "pagenumber",
+              "in": "query",
+              "description": "Pagenumber, (default:1)",
+              "schema": {
+                "type": "integer",
+                "description": "Pagenumber, (default:1)",
+                "format": "int32",
+                "default": 1
+              }
+            },
+            {
+              "name": "pagesize",
+              "in": "query",
+              "description": "Elements per Page, (default:10)",
+              "schema": {
+                "type": "integer",
+                "description": "Elements per Page, (default:10)",
+                "format": "int32",
+                "default": 10
+              }
+            },
+            {
+              "name": "articletype",
+              "in": "query",
+              "description": "Type of the Article ('null' = Filter disabled, possible values: BITMASK values: 1 = basearticle, 2 = book article, 4 = contentarticle, 8 = eventarticle, 16 = pressarticle, 32 = recipe, 64 = touroperator , 128 = b2b), (also possible for compatibily reasons: basisartikel, buchtippartikel, contentartikel, veranstaltungsartikel, presseartikel, rezeptartikel, reiseveranstalter, b2bartikel ) (default:'255' == ALL), REFERENCE TO: GET /api/ArticleTypes",
+              "schema": {
+                "type": "string",
+                "description": "Type of the Article ('null' = Filter disabled, possible values: BITMASK values: 1 = basearticle, 2 = book article, 4 = contentarticle, 8 = eventarticle, 16 = pressarticle, 32 = recipe, 64 = touroperator , 128 = b2b), (also possible for compatibily reasons: basisartikel, buchtippartikel, contentartikel, veranstaltungsartikel, presseartikel, rezeptartikel, reiseveranstalter, b2bartikel ) (default:'255' == ALL), REFERENCE TO: GET /api/ArticleTypes",
+                "default": "255",
+                "nullable": true
+              }
+            },
+            {
+              "name": "articlesubtype",
+              "in": "query",
+              "description": "Sub Type of the Article (depends on the Maintype of the Article 'null' = Filter disabled)",
+              "schema": {
+                "type": "string",
+                "description": "Sub Type of the Article (depends on the Maintype of the Article 'null' = Filter disabled)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "idlist",
+              "in": "query",
+              "description": "IDFilter (Separator ',' List of Article IDs), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "IDFilter (Separator ',' List of Article IDs), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "langfilter",
+              "in": "query",
+              "description": "Language Filter (Gets only Articles Available in the passed Language)",
+              "schema": {
+                "type": "string",
+                "description": "Language Filter (Gets only Articles Available in the passed Language)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "sortbyarticledate",
+              "in": "query",
+              "description": "Sort By Articledate ('true' sorts Articles by Articledate)",
+              "schema": {
+                "type": "boolean",
+                "description": "Sort By Articledate ('true' sorts Articles by Articledate)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhtagfilter",
+              "in": "query",
+              "description": "ODH Taglist Filter (refers to Array SmgTags) (String, Separator ',' more Tags possible, available Tags reference to 'api/ODHTag?validforentity=article'), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "ODH Taglist Filter (refers to Array SmgTags) (String, Separator ',' more Tags possible, available Tags reference to 'api/ODHTag?validforentity=article'), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhactive",
+              "in": "query",
+              "description": "ODH Active (Published) Activities Filter (Refers to field SmgActive) Article Filter (possible Values: 'true' only published Article, 'false' only not published Articles, (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "ODH Active (Published) Activities Filter (Refers to field SmgActive) Article Filter (possible Values: 'true' only published Article, 'false' only not published Articles, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "active",
+              "in": "query",
+              "description": "Active Articles Filter (possible Values: 'true' only Active Articles, 'false' only Disabled Articles",
+              "schema": {
+                "type": "boolean",
+                "description": "Active Articles Filter (possible Values: 'true' only Active Articles, 'false' only Disabled Articles",
+                "nullable": true
+              }
+            },
+            {
+              "name": "lastchange",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, 'null' disables Random Sorting, (default:null)",
+              "schema": {
+                "type": "string",
+                "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, 'null' disables Random Sorting, (default:null)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "description": "String to search for, Title in all languages are searched, (default: null)",
+              "schema": {
+                "type": "string",
+                "description": "String to search for, Title in all languages are searched, (default: null)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ArticleJsonResult"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ArticleJsonResult"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ArticleJsonResult"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ArticleJsonResult"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Article/{id}": {
+        "get": {
+          "tags": [
+            "Article"
+          ],
+          "summary": "GET Article Single",
+          "operationId": "SingleArticle",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the Poi",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the Poi",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Article"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Article"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Article"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Article"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/ArticleTypes": {
+        "get": {
+          "tags": [
+            "Article"
+          ],
+          "summary": "GET Article Types List",
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ArticleTypes"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ArticleTypes"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ArticleTypes"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ArticleTypes"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/ArticleTypes/{id}": {
+        "get": {
+          "tags": [
+            "Article"
+          ],
+          "summary": "GET Article Types Single",
+          "operationId": "SingleArticleTypes",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ArticleTypes"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ArticleTypes"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ArticleTypes"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ArticleTypes"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/MetaRegion": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET MetaRegion List",
+          "parameters": [
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/MetaRegion"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/MetaRegion"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/MetaRegion"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/MetaRegion"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/MetaRegion/{id}": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET MetaRegion Single",
+          "operationId": "SingleMetaRegion",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the requested data",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the requested data",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetaRegion"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetaRegion"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetaRegion"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/MetaRegion"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/ExperienceArea": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET Experiencearea List",
+          "parameters": [
+            {
+              "name": "visibleinsearch",
+              "in": "query",
+              "description": "Filter only Elements flagged with visibleinsearch: (possible values: 'true','false'), (default:'false')",
+              "schema": {
+                "type": "boolean",
+                "description": "Filter only Elements flagged with visibleinsearch: (possible values: 'true','false'), (default:'false')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ExperienceArea"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ExperienceArea"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ExperienceArea"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ExperienceArea"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/ExperienceArea/{id}": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET ExperienceArea Single",
+          "operationId": "SingleExperienceArea",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the requested data",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the requested data",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperienceArea"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperienceArea"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperienceArea"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ExperienceArea"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Region": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET Region List",
+          "parameters": [
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Region"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Region"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Region"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Region"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Region/{id}": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET Region Single",
+          "operationId": "SingleRegion",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the requested data",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the requested data",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Region"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Region"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Region"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Region"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/TourismAssociation": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET TourismAssociation List",
+          "parameters": [
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Tourismverein"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Tourismverein"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Tourismverein"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Tourismverein"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/TourismAssociation/{id}": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET TourismAssociation Single",
+          "operationId": "SingleTourismAssociation",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the requested data",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the requested data",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Tourismverein"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Tourismverein"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Tourismverein"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Tourismverein"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Municipality": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET Municipality List",
+          "parameters": [
+            {
+              "name": "visibleinsearch",
+              "in": "query",
+              "description": "Filter only Elements flagged with visibleinsearch: (possible values: 'true','false'), (default:'false')",
+              "schema": {
+                "type": "boolean",
+                "description": "Filter only Elements flagged with visibleinsearch: (possible values: 'true','false'), (default:'false')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Municipality"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Municipality"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Municipality"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Municipality"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Municipality/{id}": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET Municipality Single",
+          "operationId": "SingleMunicipality",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the requested data",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the requested data",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Municipality"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Municipality"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Municipality"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Municipality"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/District": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET District List",
+          "parameters": [
+            {
+              "name": "visibleinsearch",
+              "in": "query",
+              "description": "Filter only Elements flagged with visibleinsearch: (possible values: 'true','false'), (default:'false')",
+              "schema": {
+                "type": "boolean",
+                "description": "Filter only Elements flagged with visibleinsearch: (possible values: 'true','false'), (default:'false')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/District"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/District"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/District"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/District"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/District/{id}": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET District Single",
+          "operationId": "SingleDistrict",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the requested data",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the requested data",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/District"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/District"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/District"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/District"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Area": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET Area List",
+          "parameters": [
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Area"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Area"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Area"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Area"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Area/{id}": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET Area Single",
+          "operationId": "SingleArea",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the requested data",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the requested data",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Area"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Area"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Area"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Area"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/SkiRegion": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET SkiRegion List",
+          "parameters": [
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SkiRegion"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SkiRegion"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SkiRegion"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SkiRegion"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/SkiRegion/{id}": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET SkiRegion Single",
+          "operationId": "SingleSkiRegion",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the requested data",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the requested data",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SkiRegion"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SkiRegion"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SkiRegion"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SkiRegion"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/SkiArea": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET SkiArea List",
+          "parameters": [
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SkiArea"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SkiArea"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SkiArea"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SkiArea"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/SkiArea/{id}": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET SkiArea Single",
+          "operationId": "SingleSkiArea",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the requested data",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the requested data",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SkiArea"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SkiArea"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SkiArea"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SkiArea"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/WineAward": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET Wine Awards List",
+          "parameters": [
+            {
+              "name": "wineid",
+              "in": "query",
+              "description": "WineId",
+              "schema": {
+                "type": "string",
+                "description": "WineId",
+                "nullable": true
+              }
+            },
+            {
+              "name": "companyid",
+              "in": "query",
+              "description": "Company Id",
+              "schema": {
+                "type": "string",
+                "description": "Company Id",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Wine"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Wine"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Wine"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Wine"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/WineAward/{id}": {
+        "get": {
+          "tags": [
+            "Common"
+          ],
+          "summary": "GET Wine Award Single",
+          "operationId": "SingleWineAward",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the requested data",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the requested data",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SkiArea"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SkiArea"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SkiArea"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SkiArea"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Event": {
+        "get": {
+          "tags": [
+            "Event"
+          ],
+          "summary": "GET Event List",
+          "parameters": [
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "pagenumber",
+              "in": "query",
+              "description": "Pagenumber, (default:1)",
+              "schema": {
+                "type": "integer",
+                "description": "Pagenumber, (default:1)",
+                "format": "int32",
+                "default": 1
+              }
+            },
+            {
+              "name": "pagesize",
+              "in": "query",
+              "description": "Elements per Page, (default:10)",
+              "schema": {
+                "type": "integer",
+                "description": "Elements per Page, (default:10)",
+                "format": "int32",
+                "default": 10
+              }
+            },
+            {
+              "name": "idlist",
+              "in": "query",
+              "description": "IDFilter (Separator ',' List of Event IDs, 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "IDFilter (Separator ',' List of Event IDs, 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "locfilter",
+              "in": "query",
+              "description": "Locfilter (Separator ',' possible values: reg + REGIONID = (Filter by Region), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction), 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Locfilter (Separator ',' possible values: reg + REGIONID = (Filter by Region), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction), 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rancfilter",
+              "in": "query",
+              "description": "Rancfilter (Ranc 0-5 possible)",
+              "schema": {
+                "type": "string",
+                "description": "Rancfilter (Ranc 0-5 possible)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "typefilter",
+              "in": "query",
+              "description": "Typefilter (Type of Event: not used yet)",
+              "schema": {
+                "type": "string",
+                "description": "Typefilter (Type of Event: not used yet)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "topicfilter",
+              "in": "query",
+              "description": "Topic ID Filter (Filter by Topic ID) BITMASK",
+              "schema": {
+                "type": "string",
+                "description": "Topic ID Filter (Filter by Topic ID) BITMASK",
+                "nullable": true
+              }
+            },
+            {
+              "name": "orgfilter",
+              "in": "query",
+              "description": "Organization Filter (Filter by Organizer RID)",
+              "schema": {
+                "type": "string",
+                "description": "Organization Filter (Filter by Organizer RID)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhtagfilter",
+              "in": "query",
+              "description": "ODH Taglist Filter (refers to Array SmgTags) (String, Separator ',' more Tags possible, available Tags reference to 'api/ODHTag?validforentity=event'), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "ODH Taglist Filter (refers to Array SmgTags) (String, Separator ',' more Tags possible, available Tags reference to 'api/ODHTag?validforentity=event'), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "active",
+              "in": "query",
+              "description": "Active Events Filter (possible Values: 'true' only Active Events, 'false' only Disabled Events, (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "Active Events Filter (possible Values: 'true' only Active Events, 'false' only Disabled Events, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhactive",
+              "in": "query",
+              "description": "ODH Active (Published) Events Filter (Refers to field SmgActive) Events Filter (possible Values: 'true' only published Events, 'false' only not published Events, (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "ODH Active (Published) Events Filter (Refers to field SmgActive) Events Filter (possible Values: 'true' only published Events, 'false' only not published Events, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "begindate",
+              "in": "query",
+              "description": "BeginDate of Events (Format: yyyy-MM-dd)",
+              "schema": {
+                "type": "string",
+                "description": "BeginDate of Events (Format: yyyy-MM-dd)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "enddate",
+              "in": "query",
+              "description": "EndDate of Events (Format: yyyy-MM-dd)",
+              "schema": {
+                "type": "string",
+                "description": "EndDate of Events (Format: yyyy-MM-dd)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "sort",
+              "in": "query",
+              "description": "Sorting of Events ('desc': Descending, default, 'asc': Ascending)",
+              "schema": {
+                "type": "string",
+                "description": "Sorting of Events ('desc': Descending, default, 'asc': Ascending)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "lastchange",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, 'null' disables Random Sorting, (default:null)",
+              "schema": {
+                "type": "string",
+                "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, 'null' disables Random Sorting, (default:null)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "langfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "source",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "description": "String to search for, Title in all languages are searched, (default: null)",
+              "schema": {
+                "type": "string",
+                "description": "String to search for, Title in all languages are searched, (default: null)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventJsonResult"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventJsonResult"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventJsonResult"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventJsonResult"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Event/{id}": {
+        "get": {
+          "tags": [
+            "Event"
+          ],
+          "summary": "GET Event Single",
+          "operationId": "SingleEvent",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the Event",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the Event",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/EventTopics": {
+        "get": {
+          "tags": [
+            "Event"
+          ],
+          "summary": "GET Event Topic List",
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/EventTypes"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/EventTypes"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/EventTypes"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/EventTypes"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/EventTopics/{id}": {
+        "get": {
+          "tags": [
+            "Event"
+          ],
+          "summary": "GET Event Topic Single",
+          "operationId": "SingleEventTopics",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventTypes"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventTypes"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventTypes"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventTypes"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/EventShort": {
+        "get": {
+          "tags": [
+            "EventShort"
+          ],
+          "summary": "GET EventShort List",
+          "parameters": [
+            {
+              "name": "pagenumber",
+              "in": "query",
+              "description": "Pagenumber (Integer)",
+              "schema": {
+                "type": "integer",
+                "description": "Pagenumber (Integer)",
+                "format": "int32",
+                "default": 1
+              }
+            },
+            {
+              "name": "pagesize",
+              "in": "query",
+              "description": "Pagesize (Integer)",
+              "schema": {
+                "type": "integer",
+                "description": "Pagesize (Integer)",
+                "format": "int32",
+                "default": 1024
+              }
+            },
+            {
+              "name": "startdate",
+              "in": "query",
+              "description": "Format (yyyy-MM-dd HH:mm) default or Unix Timestamp",
+              "schema": {
+                "type": "string",
+                "description": "Format (yyyy-MM-dd HH:mm) default or Unix Timestamp",
+                "nullable": true
+              }
+            },
+            {
+              "name": "enddate",
+              "in": "query",
+              "description": "Format (yyyy-MM-dd HH:mm) default or Unix Timestamp",
+              "schema": {
+                "type": "string",
+                "description": "Format (yyyy-MM-dd HH:mm) default or Unix Timestamp",
+                "nullable": true
+              }
+            },
+            {
+              "name": "datetimeformat",
+              "in": "query",
+              "description": "not provided, use default format, for unix timestamp pass \"uxtimestamp\"",
+              "schema": {
+                "type": "string",
+                "description": "not provided, use default format, for unix timestamp pass \"uxtimestamp\"",
+                "nullable": true
+              }
+            },
+            {
+              "name": "source",
+              "in": "query",
+              "description": "Source of the data, (possible values 'Content' or 'EBMS')",
+              "schema": {
+                "type": "string",
+                "description": "Source of the data, (possible values 'Content' or 'EBMS')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "eventlocation",
+              "in": "query",
+              "description": "Event Location, (possible values, 'NOI' or 'EC')",
+              "schema": {
+                "type": "string",
+                "description": "Event Location, (possible values, 'NOI' or 'EC')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "onlyactive",
+              "in": "query",
+              "description": "'true' if only Events marked as Active by Eurac should be displayed",
+              "schema": {
+                "type": "boolean",
+                "description": "'true' if only Events marked as Active by Eurac should be displayed",
+                "nullable": true
+              }
+            },
+            {
+              "name": "eventids",
+              "in": "query",
+              "description": "comma separated list of event ids",
+              "schema": {
+                "type": "string",
+                "description": "comma separated list of event ids",
+                "nullable": true
+              }
+            },
+            {
+              "name": "webaddress",
+              "in": "query",
+              "description": "Searches the webaddress",
+              "schema": {
+                "type": "string",
+                "description": "Searches the webaddress",
+                "nullable": true
+              }
+            },
+            {
+              "name": "sortorder",
+              "in": "query",
+              "description": "ASC or DESC by StartDate",
+              "schema": {
+                "type": "string",
+                "description": "ASC or DESC by StartDate",
+                "default": "ASC",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "nullable": true
+              }
+            },
+            {
+              "name": "lastchange",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventShortResult"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventShortResult"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventShortResult"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventShortResult"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/EventShort/{id}": {
+        "get": {
+          "tags": [
+            "EventShort"
+          ],
+          "summary": "GET EventShort Single",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "Id of the Event",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Id of the Event",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventShort"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventShort"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventShort"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventShort"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/EventShort/Detail/{id}": {
+        "get": {
+          "tags": [
+            "EventShort"
+          ],
+          "summary": "GET EventShort Single",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "Id of the Event",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Id of the Event",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventShort"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventShort"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventShort"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/EventShort"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/EventShort/GetbyRoomBooked": {
+        "get": {
+          "tags": [
+            "EventShort"
+          ],
+          "summary": "GET EventShort List by Room Occupation",
+          "parameters": [
+            {
+              "name": "startdate",
+              "in": "query",
+              "description": "Format (yyyy-MM-dd HH:mm) default or Unix Timestamp",
+              "schema": {
+                "type": "string",
+                "description": "Format (yyyy-MM-dd HH:mm) default or Unix Timestamp",
+                "nullable": true
+              }
+            },
+            {
+              "name": "enddate",
+              "in": "query",
+              "description": "Format (yyyy-MM-dd HH:mm) default or Unix Timestamp",
+              "schema": {
+                "type": "string",
+                "description": "Format (yyyy-MM-dd HH:mm) default or Unix Timestamp",
+                "nullable": true
+              }
+            },
+            {
+              "name": "datetimeformat",
+              "in": "query",
+              "description": "not provided, use default format, for unix timestamp pass \"uxtimestamp\"",
+              "schema": {
+                "type": "string",
+                "description": "not provided, use default format, for unix timestamp pass \"uxtimestamp\"",
+                "nullable": true
+              }
+            },
+            {
+              "name": "source",
+              "in": "query",
+              "description": "Source of the data, (possible values 'Content' or 'EBMS')",
+              "schema": {
+                "type": "string",
+                "description": "Source of the data, (possible values 'Content' or 'EBMS')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "eventlocation",
+              "in": "query",
+              "description": "Event Location, (possible values, 'NOI' or 'EC')",
+              "schema": {
+                "type": "string",
+                "description": "Event Location, (possible values, 'NOI' or 'EC')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "onlyactive",
+              "in": "query",
+              "description": "'true' if only Events marked as Active by Eurac should be displayed",
+              "schema": {
+                "type": "boolean",
+                "description": "'true' if only Events marked as Active by Eurac should be displayed",
+                "nullable": true
+              }
+            },
+            {
+              "name": "eventids",
+              "in": "query",
+              "description": "comma separated list of event ids",
+              "schema": {
+                "type": "string",
+                "description": "comma separated list of event ids",
+                "nullable": true
+              }
+            },
+            {
+              "name": "webaddress",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/EventShortByRoom"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/EventShortByRoom"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/EventShortByRoom"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/EventShortByRoom"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/EventShort/RoomMapping": {
+        "get": {
+          "tags": [
+            "EventShort"
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Gastronomy": {
+        "get": {
+          "tags": [
+            "Gastronomy"
+          ],
+          "summary": "GET Gastronomy List",
+          "parameters": [
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "pagenumber",
+              "in": "query",
+              "description": "Pagenumber, (default:1)",
+              "schema": {
+                "type": "integer",
+                "description": "Pagenumber, (default:1)",
+                "format": "int32",
+                "default": 1
+              }
+            },
+            {
+              "name": "pagesize",
+              "in": "query",
+              "description": "Elements per Page, (default:10)",
+              "schema": {
+                "type": "integer",
+                "description": "Elements per Page, (default:10)",
+                "format": "int32",
+                "default": 10
+              }
+            },
+            {
+              "name": "idlist",
+              "in": "query",
+              "description": "IDFilter (Separator ',' List of Activity IDs), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "IDFilter (Separator ',' List of Activity IDs), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "locfilter",
+              "in": "query",
+              "description": "Locfilter (Separator ',' possible values: reg + REGIONID = (Filter by Region), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction)), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Locfilter (Separator ',' possible values: reg + REGIONID = (Filter by Region), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction)), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "dishcodefilter",
+              "in": "query",
+              "description": "Dish Code Filter (BITMASK values: 1 = (Speisen), 2 = (Vorspeise), 4 = (Hauptspeise), 8 = (Nachspeise), 16 = (Tagesgericht), 32 = (Menü), 64 = (Degustationsmenü), 128 = (Kindermenüs), 256 = (Mittagsmenüs)",
+              "schema": {
+                "type": "string",
+                "description": "Dish Code Filter (BITMASK values: 1 = (Speisen), 2 = (Vorspeise), 4 = (Hauptspeise), 8 = (Nachspeise), 16 = (Tagesgericht), 32 = (Menü), 64 = (Degustationsmenü), 128 = (Kindermenüs), 256 = (Mittagsmenüs)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "ceremonycodefilter",
+              "in": "query",
+              "description": "Ceremony Code Filter (BITMASK  values: 1 = (Familienfeiern), 2 = (Hochzeiten), 4 = (Geburtstagsfeiern), 8 = (Firmenessen), 16 = (Weihnachtsessen), 32 = (Sylvestermenü), 64 = (Seminare / Tagungen), 128 = (Versammlungen)",
+              "schema": {
+                "type": "string",
+                "description": "Ceremony Code Filter (BITMASK  values: 1 = (Familienfeiern), 2 = (Hochzeiten), 4 = (Geburtstagsfeiern), 8 = (Firmenessen), 16 = (Weihnachtsessen), 32 = (Sylvestermenü), 64 = (Seminare / Tagungen), 128 = (Versammlungen)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "categorycodefilter",
+              "in": "query",
+              "description": "Category Code Filter (BITMASK  values: 1 = (Restaurant), 2 = (Bar / Café / Bistro), 4 = (Pub / Disco), 8 = (Apres Ski), 16 = (Jausenstation), 32 = (Pizzeria), 64 = (Bäuerlicher Schankbetrieb), 128 = (Buschenschank), 256 = (Hofschank), 512 = (Törggele Lokale), 1024 = (Schnellimbiss), 2048 = (Mensa), 4096 = (Vinothek /Weinhaus / Taverne), 8192 = (Eisdiele), 16348 = (Gasthaus), 32768 = (Gasthof), 65536 = (Braugarten), 131072 = (Schutzhütte), 262144 = (Alm), 524288 = (Skihütte)",
+              "schema": {
+                "type": "string",
+                "description": "Category Code Filter (BITMASK  values: 1 = (Restaurant), 2 = (Bar / Café / Bistro), 4 = (Pub / Disco), 8 = (Apres Ski), 16 = (Jausenstation), 32 = (Pizzeria), 64 = (Bäuerlicher Schankbetrieb), 128 = (Buschenschank), 256 = (Hofschank), 512 = (Törggele Lokale), 1024 = (Schnellimbiss), 2048 = (Mensa), 4096 = (Vinothek /Weinhaus / Taverne), 8192 = (Eisdiele), 16348 = (Gasthaus), 32768 = (Gasthof), 65536 = (Braugarten), 131072 = (Schutzhütte), 262144 = (Alm), 524288 = (Skihütte)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "facilitycodefilter",
+              "in": "query",
+              "description": "Facility Code Filter (BITMASK  values: 1 = (American Express), 2 = (Diners Club), 4 = (Eurocard / Mastercard), 8 = (Visa), 16 = (Hunde erlaubt), 32 = (Geeignet für Busse), 64 = (Garten), 128 = (Garagen), 256 = (Bierbar), 512 = (Kinderspielplatz), 1024 = (Spielzimmer), 2048 = (Spielplatz), 4096 = (Parkplätze), 8192 = (Raucherräume), 16348 = (Terrasse), 32768 = (Behindertengerecht), 65536 = (Biergarten), 131072 = (Aussichtsterrasse), 262144 = (Wintergarten), 524288 = (Gault Millau Südtirol), 1048576 = (Guida Espresso), 2097152 = (Gambero Rosso), 4194304 = (Feinschmecker), 8388608 = (Aral Schlemmer Atlas), 16777216 = (Varta Führer), 33554432 = (Bertelsmann), 67108864 = (Preis für Südtiroler Weinkultur), 134217728 = (Michelin), 268435456 = (Roter Hahn), 536870912 = (Tafelspitz))",
+              "schema": {
+                "type": "string",
+                "description": "Facility Code Filter (BITMASK  values: 1 = (American Express), 2 = (Diners Club), 4 = (Eurocard / Mastercard), 8 = (Visa), 16 = (Hunde erlaubt), 32 = (Geeignet für Busse), 64 = (Garten), 128 = (Garagen), 256 = (Bierbar), 512 = (Kinderspielplatz), 1024 = (Spielzimmer), 2048 = (Spielplatz), 4096 = (Parkplätze), 8192 = (Raucherräume), 16348 = (Terrasse), 32768 = (Behindertengerecht), 65536 = (Biergarten), 131072 = (Aussichtsterrasse), 262144 = (Wintergarten), 524288 = (Gault Millau Südtirol), 1048576 = (Guida Espresso), 2097152 = (Gambero Rosso), 4194304 = (Feinschmecker), 8388608 = (Aral Schlemmer Atlas), 16777216 = (Varta Führer), 33554432 = (Bertelsmann), 67108864 = (Preis für Südtiroler Weinkultur), 134217728 = (Michelin), 268435456 = (Roter Hahn), 536870912 = (Tafelspitz))",
+                "nullable": true
+              }
+            },
+            {
+              "name": "cuisinecodefilter",
+              "in": "query",
+              "description": "Cuisine Code Filter (BITMASK  values: 1 = (Vegetarische Küche), 2 = (Glutenfreie Küche), 4 = (Laktosefreie Kost), 8 = (Warme Küche), 16 = (Südtiroler Spezialitäten), 32 = (Gourmet Küche), 64 = (Italienische Küche), 128 = (Internationale Küche), 256 = (Pizza), 512 = (Fischspezialitäten), 1024 = (Asiatische Küche), 2048 = (Wildspezialitäten), 4096 = (Produkte eigener Erzeugung), 8192 = (Diätküche), 16348 = (Grillspezialitäten), 32768 = (Ladinische Küche), 65536 = (Kleine Karte), 131072 = (Fischwochen), 262144 = (Spargelwochen), 524288 = (Lammwochen), 1048576 = (Wildwochen), 2097152 = (Vorspeisewochen), 4194304 = (Nudelwochen), 8388608 = (Kräuterwochen), 16777216 = (Kindermenüs), 33554432 = (Mittagsmenüs))",
+              "schema": {
+                "type": "string",
+                "description": "Cuisine Code Filter (BITMASK  values: 1 = (Vegetarische Küche), 2 = (Glutenfreie Küche), 4 = (Laktosefreie Kost), 8 = (Warme Küche), 16 = (Südtiroler Spezialitäten), 32 = (Gourmet Küche), 64 = (Italienische Küche), 128 = (Internationale Küche), 256 = (Pizza), 512 = (Fischspezialitäten), 1024 = (Asiatische Küche), 2048 = (Wildspezialitäten), 4096 = (Produkte eigener Erzeugung), 8192 = (Diätküche), 16348 = (Grillspezialitäten), 32768 = (Ladinische Küche), 65536 = (Kleine Karte), 131072 = (Fischwochen), 262144 = (Spargelwochen), 524288 = (Lammwochen), 1048576 = (Wildwochen), 2097152 = (Vorspeisewochen), 4194304 = (Nudelwochen), 8388608 = (Kräuterwochen), 16777216 = (Kindermenüs), 33554432 = (Mittagsmenüs))",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhtagfilter",
+              "in": "query",
+              "description": "ODH Taglist Filter (refers to Array SmgTags) (String, Separator ',' more Tags possible, available Tags reference to 'api/ODHTag?validforentity=gastronomy'), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "ODH Taglist Filter (refers to Array SmgTags) (String, Separator ',' more Tags possible, available Tags reference to 'api/ODHTag?validforentity=gastronomy'), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "active",
+              "in": "query",
+              "description": "Active Gastronomies Filter (possible Values: 'true' only Active Gastronomies, 'false' only Disabled Gastronomies",
+              "schema": {
+                "type": "boolean",
+                "description": "Active Gastronomies Filter (possible Values: 'true' only Active Gastronomies, 'false' only Disabled Gastronomies",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhactive",
+              "in": "query",
+              "description": "ODH Active (Published) Gastronomies Filter (Refers to field SmgActive) Gastronomies Filter (possible Values: 'true' only published Gastronomies, 'false' only not published Gastronomies, (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "ODH Active (Published) Gastronomies Filter (Refers to field SmgActive) Gastronomies Filter (possible Values: 'true' only published Gastronomies, 'false' only not published Gastronomies, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "lastchange",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, 'null' disables Random Sorting, (default:null)",
+              "schema": {
+                "type": "string",
+                "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, 'null' disables Random Sorting, (default:null)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "description": "String to search for, Title in all languages are searched, (default: null)",
+              "schema": {
+                "type": "string",
+                "description": "String to search for, Title in all languages are searched, (default: null)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GastronomyJsonResult"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GastronomyJsonResult"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GastronomyJsonResult"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GastronomyJsonResult"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Gastronomy/{id}": {
+        "get": {
+          "tags": [
+            "Gastronomy"
+          ],
+          "summary": "GET Gastronomy Single",
+          "operationId": "SingleGastronomy",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the Gastronomy",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the Gastronomy",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSActivity"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSActivity"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSActivity"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSActivity"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/GastronomyTypes": {
+        "get": {
+          "tags": [
+            "Gastronomy"
+          ],
+          "summary": "GET Gastronomy Types List",
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/GastronomyTypes"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/GastronomyTypes"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/GastronomyTypes"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/GastronomyTypes"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/GastronomyTypes/{id}": {
+        "get": {
+          "tags": [
+            "Gastronomy"
+          ],
+          "summary": "GET Gastronomy Types Single",
+          "operationId": "SingleGastronomyTypes",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GastronomyTypes"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GastronomyTypes"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GastronomyTypes"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GastronomyTypes"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Location": {
+        "get": {
+          "tags": [
+            "Location"
+          ],
+          "summary": "GET Location List (Use in locfilter)",
+          "parameters": [
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Localization Language, (default:'en')",
+              "schema": {
+                "type": "string",
+                "description": "Localization Language, (default:'en')",
+                "default": "en",
+                "nullable": true
+              }
+            },
+            {
+              "name": "type",
+              "in": "query",
+              "description": "Type ('mta','reg','tvs','mun','fra') Separator ',' : 'null' returns all Location Objects (default)",
+              "schema": {
+                "type": "string",
+                "description": "Type ('mta','reg','tvs','mun','fra') Separator ',' : 'null' returns all Location Objects (default)",
+                "default": "null",
+                "nullable": true
+              }
+            },
+            {
+              "name": "showall",
+              "in": "query",
+              "description": "Show all Data (true = all, false = show only data market as visible)",
+              "schema": {
+                "type": "boolean",
+                "description": "Show all Data (true = all, false = show only data market as visible)",
+                "default": true
+              }
+            },
+            {
+              "name": "locfilter",
+              "in": "query",
+              "description": "Locfilter (Separator ',' possible values: mta + MetaREGIONID = (Filter by MetaRegion), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction)), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Locfilter (Separator ',' possible values: mta + MetaREGIONID = (Filter by MetaRegion), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction)), (default:'null')",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/LocHelperclass"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/LocHelperclass"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/LocHelperclass"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/LocHelperclass"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Location/Skiarea": {
+        "get": {
+          "tags": [
+            "Location"
+          ],
+          "summary": "GET Skiarea List (Use in locfilter as \"ska\")",
+          "parameters": [
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Localization Language, (default:'en')",
+              "schema": {
+                "type": "string",
+                "description": "Localization Language, (default:'en')",
+                "default": "en",
+                "nullable": true
+              }
+            },
+            {
+              "name": "locfilter",
+              "in": "query",
+              "description": "Locfilter (Separator ',' possible values: mta + MetaREGIONID = (Filter by MetaRegion), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Locfilter (Separator ',' possible values: mta + MetaREGIONID = (Filter by MetaRegion), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), (default:'null')",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/LocHelperclass"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/LocHelperclass"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/LocHelperclass"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/LocHelperclass"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api": {
+        "get": {
+          "tags": [
+            "Main"
+          ],
+          "operationId": "TourismApi",
+          "responses": {
+            "200": {
+              "description": "Success"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/ODHActivityPoi": {
+        "get": {
+          "tags": [
+            "ODHActivityPoi"
+          ],
+          "summary": "GET ODHActivityPoi List",
+          "parameters": [
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "pagenumber",
+              "in": "query",
+              "description": "Pagenumber, (default:1)",
+              "schema": {
+                "type": "integer",
+                "description": "Pagenumber, (default:1)",
+                "format": "int32",
+                "default": 1
+              }
+            },
+            {
+              "name": "pagesize",
+              "in": "query",
+              "description": "Elements per Page, (default:10)",
+              "schema": {
+                "type": "integer",
+                "description": "Elements per Page, (default:10)",
+                "format": "int32",
+                "default": 10
+              }
+            },
+            {
+              "name": "type",
+              "in": "query",
+              "description": "Type of the ODHActivityPoi ('null' = Filter disabled, possible values: BITMASK: 1 = Wellness, 2 = Winter, 4 = Summer, 8 = Culture, 16 = Other, 32 = Gastronomy), (default: 63 == ALL), REFERENCE TO: GET /api/ODHActivityPoiTypes",
+              "schema": {
+                "type": "string",
+                "description": "Type of the ODHActivityPoi ('null' = Filter disabled, possible values: BITMASK: 1 = Wellness, 2 = Winter, 4 = Summer, 8 = Culture, 16 = Other, 32 = Gastronomy), (default: 63 == ALL), REFERENCE TO: GET /api/ODHActivityPoiTypes",
+                "default": "63",
+                "nullable": true
+              }
+            },
+            {
+              "name": "subtype",
+              "in": "query",
+              "description": "Subtype of the ODHActivityPoi ('null' = Filter disabled, BITMASK Filter, available SubTypes depends on the selected Maintype reference to ODHActivityPoiTypes)",
+              "schema": {
+                "type": "string",
+                "description": "Subtype of the ODHActivityPoi ('null' = Filter disabled, BITMASK Filter, available SubTypes depends on the selected Maintype reference to ODHActivityPoiTypes)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "poitype",
+              "in": "query",
+              "description": "Additional Type of the ODHActivityPoi ('null' = Filter disabled, BITMASK Filter, available SubTypes depends on the selected Maintype, SubType reference to ODHActivityPoiTypes)",
+              "schema": {
+                "type": "string",
+                "description": "Additional Type of the ODHActivityPoi ('null' = Filter disabled, BITMASK Filter, available SubTypes depends on the selected Maintype, SubType reference to ODHActivityPoiTypes)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "idlist",
+              "in": "query",
+              "description": "IDFilter (Separator ',' List of ODHActivityPoi IDs), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "IDFilter (Separator ',' List of ODHActivityPoi IDs), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "locfilter",
+              "in": "query",
+              "description": "Locfilter (Separator ',' possible values: reg + REGIONID = (Filter by Region), reg + REGIONID = (Filter by Region), tvs + TOURISMASSOCIATIONID = (Filter by Tourismassociation), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction), 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Locfilter (Separator ',' possible values: reg + REGIONID = (Filter by Region), reg + REGIONID = (Filter by Region), tvs + TOURISMASSOCIATIONID = (Filter by Tourismassociation), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction), 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "langfilter",
+              "in": "query",
+              "description": "ODHActivityPoi Langfilter (returns only SmgPois available in the selected Language, Separator ',' possible values: 'de,it,en,nl,sc,pl,fr,ru', 'null': Filter disabled)",
+              "schema": {
+                "type": "string",
+                "description": "ODHActivityPoi Langfilter (returns only SmgPois available in the selected Language, Separator ',' possible values: 'de,it,en,nl,sc,pl,fr,ru', 'null': Filter disabled)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "areafilter",
+              "in": "query",
+              "description": "AreaFilter (Alternate Locfilter, can be combined with locfilter) (Separator ',' possible values: reg + REGIONID = (Filter by Region), tvs + TOURISMASSOCIATIONID = (Filter by Tourismassociation), skr + SKIREGIONID = (Filter by Skiregion), ska + SKIAREAID = (Filter by Skiarea), are + AREAID = (Filter by LTS Area), 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "AreaFilter (Alternate Locfilter, can be combined with locfilter) (Separator ',' possible values: reg + REGIONID = (Filter by Region), tvs + TOURISMASSOCIATIONID = (Filter by Tourismassociation), skr + SKIREGIONID = (Filter by Skiregion), ska + SKIAREAID = (Filter by Skiarea), are + AREAID = (Filter by LTS Area), 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "highlight",
+              "in": "query",
+              "description": "Hightlight Filter (possible values: 'false' = only ODHActivityPoi with Highlight false, 'true' = only ODHActivityPoi with Highlight true), (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "Hightlight Filter (possible values: 'false' = only ODHActivityPoi with Highlight false, 'true' = only ODHActivityPoi with Highlight true), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "source",
+              "in": "query",
+              "description": "Source Filter (possible Values: 'null' Displays all ODHActivityPoi, 'None', 'ActivityData', 'PoiData', 'GastronomicData', 'MuseumData', 'Magnolia', 'Content', 'SuedtirolWein', 'ArchApp' (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Source Filter (possible Values: 'null' Displays all ODHActivityPoi, 'None', 'ActivityData', 'PoiData', 'GastronomicData', 'MuseumData', 'Magnolia', 'Content', 'SuedtirolWein', 'ArchApp' (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhtagfilter",
+              "in": "query",
+              "description": "ODH Taglist Filter (refers to Array SmgTags) (String, Separator ',' more Tags possible, available Tags reference to 'api/ODHTag?validforentity=smgpoi'), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "ODH Taglist Filter (refers to Array SmgTags) (String, Separator ',' more Tags possible, available Tags reference to 'api/ODHTag?validforentity=smgpoi'), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhactive",
+              "in": "query",
+              "description": "ODH Active (Published) ODHActivityPoi Filter (Refers to field SmgActive) (possible Values: 'true' only published ODHActivityPoi, 'false' only not published ODHActivityPoi, (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "ODH Active (Published) ODHActivityPoi Filter (Refers to field SmgActive) (possible Values: 'true' only published ODHActivityPoi, 'false' only not published ODHActivityPoi, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "active",
+              "in": "query",
+              "description": "Active ODHActivityPoi Filter (possible Values: 'true' only active ODHActivityPoi, 'false' only not active ODHActivityPoi, (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "Active ODHActivityPoi Filter (possible Values: 'true' only active ODHActivityPoi, 'false' only not active ODHActivityPoi, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "lastchange",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, not provided disables Random Sorting, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, not provided disables Random Sorting, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "description": "String to search for, Title in all languages are searched, (default: null)",
+              "schema": {
+                "type": "string",
+                "description": "String to search for, Title in all languages are searched, (default: null)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ODHActivityPoiJsonResult"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ODHActivityPoiJsonResult"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ODHActivityPoiJsonResult"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ODHActivityPoiJsonResult"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/ODHActivityPoi/{id}": {
+        "get": {
+          "tags": [
+            "ODHActivityPoi"
+          ],
+          "summary": "GET ODHActivityPoi Single",
+          "operationId": "SingleODHActivityPoi",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the Poi",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the Poi",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ODHActivityPoi"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ODHActivityPoi"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ODHActivityPoi"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ODHActivityPoi"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/ODHActivityPoiTypes": {
+        "get": {
+          "tags": [
+            "ODHActivityPoi"
+          ],
+          "summary": "GET ODHActivityPoi Types List",
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SmgPoiTypes"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SmgPoiTypes"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SmgPoiTypes"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SmgPoiTypes"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/ODHActivityPoiTypes/{id}": {
+        "get": {
+          "tags": [
+            "ODHActivityPoi"
+          ],
+          "summary": "GET ODHActivityPoi Types Single",
+          "operationId": "SingleODHActivityPoiTypes",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SmgPoiTypes"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SmgPoiTypes"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SmgPoiTypes"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SmgPoiTypes"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/ODHTag": {
+        "get": {
+          "tags": [
+            "ODHTag"
+          ],
+          "summary": "GET ODHTag List",
+          "parameters": [
+            {
+              "name": "language",
+              "in": "query",
+              "description": "",
+              "schema": {
+                "type": "string",
+                "description": "",
+                "nullable": true
+              }
+            },
+            {
+              "name": "validforentity",
+              "in": "query",
+              "description": "Filter on Tags valid on Entitys (accommodation, activity, poi, smgpoi, package, gastronomy, event, article, common .. etc..)",
+              "schema": {
+                "type": "string",
+                "description": "Filter on Tags valid on Entitys (accommodation, activity, poi, smgpoi, package, gastronomy, event, article, common .. etc..)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "localizationlanguage",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SmgTags"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SmgTags"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SmgTags"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SmgTags"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/ODHTag/{id}": {
+        "get": {
+          "tags": [
+            "ODHTag"
+          ],
+          "summary": "GET ODHTag Single",
+          "operationId": "SingleODHTag",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "",
+              "schema": {
+                "type": "string",
+                "description": "",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "nullable": true
+              }
+            },
+            {
+              "name": "localizationlanguage",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SmgTags"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SmgTags"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SmgTags"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SmgTags"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Poi": {
+        "get": {
+          "tags": [
+            "Poi"
+          ],
+          "summary": "GET Poi List",
+          "parameters": [
+            {
+              "name": "language",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "pagenumber",
+              "in": "query",
+              "description": "Pagenumber, (default:1)",
+              "schema": {
+                "type": "integer",
+                "description": "Pagenumber, (default:1)",
+                "format": "int32",
+                "default": 1
+              }
+            },
+            {
+              "name": "pagesize",
+              "in": "query",
+              "description": "Elements per Page, (default:10)",
+              "schema": {
+                "type": "integer",
+                "description": "Elements per Page, (default:10)",
+                "format": "int32",
+                "default": 10
+              }
+            },
+            {
+              "name": "poitype",
+              "in": "query",
+              "description": "Type of the Poi ('null' = Filter disabled, possible values: BITMASK 'Doctors, Pharmacies = 1','Shops = 2','Culture and sights= 4','Nightlife and entertainment = 8','Public institutions = 16','Sports and leisure = 32','Traffic and transport = 64', 'Service providers' = 128, 'Craft' = 256), (default:'511' == ALL), REFERENCE TO: GET /api/PoiTypes",
+              "schema": {
+                "type": "string",
+                "description": "Type of the Poi ('null' = Filter disabled, possible values: BITMASK 'Doctors, Pharmacies = 1','Shops = 2','Culture and sights= 4','Nightlife and entertainment = 8','Public institutions = 16','Sports and leisure = 32','Traffic and transport = 64', 'Service providers' = 128, 'Craft' = 256), (default:'511' == ALL), REFERENCE TO: GET /api/PoiTypes",
+                "default": "511",
+                "nullable": true
+              }
+            },
+            {
+              "name": "subtype",
+              "in": "query",
+              "description": "Subtype of the Poi ('null' = Filter disabled, available Subtypes depends on the poitype BITMASK), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Subtype of the Poi ('null' = Filter disabled, available Subtypes depends on the poitype BITMASK), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "idlist",
+              "in": "query",
+              "description": "IDFilter (Separator ',' List of Activity IDs, 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "IDFilter (Separator ',' List of Activity IDs, 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "areafilter",
+              "in": "query",
+              "description": "AreaFilter (Alternate Locfilter, can be combined with locfilter) (Separator ',' possible values: reg + REGIONID = (Filter by Region), tvs + TOURISMASSOCIATIONID = (Filter by Tourismassociation), skr + SKIREGIONID = (Filter by Skiregion), ska + SKIAREAID = (Filter by Skiarea), are + AREAID = (Filter by LTS Area), 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "AreaFilter (Alternate Locfilter, can be combined with locfilter) (Separator ',' possible values: reg + REGIONID = (Filter by Region), tvs + TOURISMASSOCIATIONID = (Filter by Tourismassociation), skr + SKIREGIONID = (Filter by Skiregion), ska + SKIAREAID = (Filter by Skiarea), are + AREAID = (Filter by LTS Area), 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "highlight",
+              "in": "query",
+              "description": "Highlight Filter (Show only Highlights possible values: 'true' : show only Highlight Pois, 'null' Filter disabled), (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "Highlight Filter (Show only Highlights possible values: 'true' : show only Highlight Pois, 'null' Filter disabled), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "locfilter",
+              "in": "query",
+              "description": "Locfilter (Separator ',' possible values: reg + REGIONID = (Filter by Region), reg + REGIONID = (Filter by Region), tvs + TOURISMASSOCIATIONID = (Filter by Tourismassociation), 'null' = No Filter), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Locfilter (Separator ',' possible values: reg + REGIONID = (Filter by Region), reg + REGIONID = (Filter by Region), tvs + TOURISMASSOCIATIONID = (Filter by Tourismassociation), 'null' = No Filter), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhtagfilter",
+              "in": "query",
+              "description": "ODH Taglist Filter (refers to Array SmgTags) (String, Separator ',' more Tags possible, available Tags reference to 'api/ODHTag?validforentity=poi'), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "ODH Taglist Filter (refers to Array SmgTags) (String, Separator ',' more Tags possible, available Tags reference to 'api/ODHTag?validforentity=poi'), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "active",
+              "in": "query",
+              "description": "Active Pois Filter (possible Values: 'true' only Active Pois, 'false' only Disabled Pois, (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "Active Pois Filter (possible Values: 'true' only Active Pois, 'false' only Disabled Pois, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhactive",
+              "in": "query",
+              "description": "ODH Active (Published) Pois Filter (Refers to field SmgActive) Pois Filter (possible Values: 'true' only published Pois, 'false' only not published Pois, (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "ODH Active (Published) Pois Filter (Refers to field SmgActive) Pois Filter (possible Values: 'true' only published Pois, 'false' only not published Pois, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "lastchange",
+              "in": "query",
+              "description": "Returns data changed after this date Format (yyyy-MM-dd), (default: 'null')",
+              "schema": {
+                "type": "string",
+                "description": "Returns data changed after this date Format (yyyy-MM-dd), (default: 'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, 'null' disables Random Sorting, (default:null)",
+              "schema": {
+                "type": "string",
+                "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, 'null' disables Random Sorting, (default:null)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in Meters. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSPoiJsonResult"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSPoiJsonResult"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSPoiJsonResult"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSPoiJsonResult"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Poi/{id}": {
+        "get": {
+          "tags": [
+            "Poi"
+          ],
+          "summary": "GET Poi Single",
+          "operationId": "SinglePoi",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the Poi",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the Poi",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSPoi"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSPoi"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSPoi"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/GBLTSPoi"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/PoiTypes": {
+        "get": {
+          "tags": [
+            "Poi"
+          ],
+          "summary": "GET Poi Types List",
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PoiTypes"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PoiTypes"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PoiTypes"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PoiTypes"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/PoiTypes/{id}": {
+        "get": {
+          "tags": [
+            "Poi"
+          ],
+          "summary": "GET Poi Types Single",
+          "operationId": "SinglePoiTypes",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/PoiTypes"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/PoiTypes"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/PoiTypes"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/PoiTypes"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Venue": {
+        "get": {
+          "tags": [
+            "Venue"
+          ],
+          "summary": "GET Venue List",
+          "parameters": [
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "pagenumber",
+              "in": "query",
+              "description": "Pagenumber, (default:1)",
+              "schema": {
+                "type": "integer",
+                "description": "Pagenumber, (default:1)",
+                "format": "int32",
+                "default": 1
+              }
+            },
+            {
+              "name": "pagesize",
+              "in": "query",
+              "description": "Elements per Page (max 1024), (default:10)",
+              "schema": {
+                "type": "integer",
+                "description": "Elements per Page (max 1024), (default:10)",
+                "format": "int32",
+                "default": 10
+              }
+            },
+            {
+              "name": "categoryfilter",
+              "in": "query",
+              "description": "Venue Category Filter (BITMASK) (Separator ',' List of Venuetype Bitmasks, refer to api/VenueTypes type:category), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Venue Category Filter (BITMASK) (Separator ',' List of Venuetype Bitmasks, refer to api/VenueTypes type:category), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "capacityfilter",
+              "in": "query",
+              "description": "Capacity Range Filter (Separator ',' example Value: 50,100 All Venues with rooms from 50 to 100 people), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Capacity Range Filter (Separator ',' example Value: 50,100 All Venues with rooms from 50 to 100 people), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "roomcountfilter",
+              "in": "query",
+              "description": "Room Count Range Filter (Separator ',' example Value: 2,5 All Venues with 2 to 5 rooms), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Room Count Range Filter (Separator ',' example Value: 2,5 All Venues with 2 to 5 rooms), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "idlist",
+              "in": "query",
+              "description": "IDFilter (Separator ',' List of Venue IDs), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "IDFilter (Separator ',' List of Venue IDs), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "locfilter",
+              "in": "query",
+              "description": "Locfilter (Separator ',' possible values: mta + METAREGIONID = (Filter by Metaregion), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction)), (default:'null' = disabled)",
+              "schema": {
+                "type": "string",
+                "description": "Locfilter (Separator ',' possible values: mta + METAREGIONID = (Filter by Metaregion), reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction)), (default:'null' = disabled)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "featurefilter",
+              "in": "query",
+              "description": "Venue Features Filter (BITMASK) (Separator ',' List of Venuetype Bitmasks, refer to api/VenueTypes type:feature), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Venue Features Filter (BITMASK) (Separator ',' List of Venuetype Bitmasks, refer to api/VenueTypes type:feature), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "setuptypefilter",
+              "in": "query",
+              "description": "Venue SetupType Filter (BITMASK) (Separator ',' List of Venuetype Bitmasks, refer to api/VenueTypes type:seatType), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Venue SetupType Filter (BITMASK) (Separator ',' List of Venuetype Bitmasks, refer to api/VenueTypes type:seatType), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhtagfilter",
+              "in": "query",
+              "description": "ODH Taglist Filter (refers to Array SmgTags)(String, Separator ',' more Tags possible, available Tags reference to 'api/SmgTag/ByMainEntity/SmgPoi'), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "ODH Taglist Filter (refers to Array SmgTags)(String, Separator ',' more Tags possible, available Tags reference to 'api/SmgTag/ByMainEntity/SmgPoi'), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "source",
+              "in": "query",
+              "description": "Source Filter(String, ), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Source Filter(String, ), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "active",
+              "in": "query",
+              "description": "Active Venue Filter (possible Values: 'true' only Active Gastronomies, 'false' only Disabled Venues",
+              "schema": {
+                "type": "boolean",
+                "description": "Active Venue Filter (possible Values: 'true' only Active Gastronomies, 'false' only Disabled Venues",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhactive",
+              "in": "query",
+              "description": "ODH Active (Published) Venue Filter (possible Values: 'true' only published Venue, 'false' only not published Venue, (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "ODH Active (Published) Venue Filter (possible Values: 'true' only published Venue, 'false' only not published Venue, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "lastchange",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, not provided disables Random Sorting, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, not provided disables Random Sorting, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in KM. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in KM. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "description": "String to search for, Title in all languages are searched, (default: null)",
+              "schema": {
+                "type": "string",
+                "description": "String to search for, Title in all languages are searched, (default: null)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DDVenueJsonResult"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DDVenueJsonResult"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DDVenueJsonResult"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DDVenueJsonResult"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Venue/{id}": {
+        "get": {
+          "tags": [
+            "Venue"
+          ],
+          "summary": "GET Venue Single",
+          "operationId": "SingleVenue",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the Venue",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the Venue",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Object created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DDVenue"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DDVenue"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DDVenue"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/DDVenue"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/VenueTypes": {
+        "get": {
+          "tags": [
+            "Venue"
+          ],
+          "summary": "GET Venue Types List",
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/VenueType"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/VenueType"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/VenueType"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/VenueType"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/VenueTypes/{id}": {
+        "get": {
+          "tags": [
+            "Venue"
+          ],
+          "summary": "GET Venue Types Single",
+          "operationId": "SingleVenueTypes",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/VenueType"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/VenueType"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/VenueType"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/VenueType"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Weather": {
+        "get": {
+          "tags": [
+            "Weather"
+          ],
+          "summary": "GET Current Suedtirol Weather LIVE",
+          "parameters": [
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language",
+              "schema": {
+                "type": "string",
+                "description": "Language",
+                "default": "en",
+                "nullable": true
+              }
+            },
+            {
+              "name": "locfilter",
+              "in": "query",
+              "description": "Locfilter (possible values: filter by StationData 1 = Schlanders, 2 = Meran, 3 = Bozen, 4 = Sterzing, 5 = Brixen, 6 = Bruneck | filter nearest Station to Region,TV,Municipality,Fraction reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction), '' = No Filter). IF a Locfilter is set, only Stationdata is provided.",
+              "schema": {
+                "type": "string",
+                "description": "Locfilter (possible values: filter by StationData 1 = Schlanders, 2 = Meran, 3 = Bozen, 4 = Sterzing, 5 = Brixen, 6 = Bruneck | filter nearest Station to Region,TV,Municipality,Fraction reg + REGIONID = (Filter by Region), tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction), '' = No Filter). IF a Locfilter is set, only Stationdata is provided.",
+                "nullable": true
+              }
+            },
+            {
+              "name": "extended",
+              "in": "query",
+              "schema": {
+                "type": "boolean",
+                "default": false
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Weather"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Weather"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Weather"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Weather"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Weather/District": {
+        "get": {
+          "tags": [
+            "Weather"
+          ],
+          "summary": "GET District Weather LIVE",
+          "parameters": [
+            {
+              "name": "locfilter",
+              "in": "query",
+              "description": "Locfilter (possible values: filter by District 1 = Etschtal/Überetsch/Unterland, 2 = Burggrafenamt, 3 = Vinschgau, 4 = Eisacktal und Sarntal, 5 = Wipptal, 6 = Pustertal/Dolomiten, 7 = Ladinien-Dolomiten | filter nearest DistrictWeather to Region,TV,Municipality,Fraction tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction))",
+              "schema": {
+                "type": "string",
+                "description": "Locfilter (possible values: filter by District 1 = Etschtal/Überetsch/Unterland, 2 = Burggrafenamt, 3 = Vinschgau, 4 = Eisacktal und Sarntal, 5 = Wipptal, 6 = Pustertal/Dolomiten, 7 = Ladinien-Dolomiten | filter nearest DistrictWeather to Region,TV,Municipality,Fraction tvs + TOURISMVEREINID = (Filter by Tourismverein), mun + MUNICIPALITYID = (Filter by Municipality), fra + FRACTIONID = (Filter by Fraction))",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language",
+              "schema": {
+                "type": "string",
+                "description": "Language",
+                "default": "en",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/BezirksWeather"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/BezirksWeather"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/BezirksWeather"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/BezirksWeather"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Weather/Realtime": {
+        "get": {
+          "tags": [
+            "Weather"
+          ],
+          "summary": "GET Current Realtime Weather LIVE",
+          "parameters": [
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language",
+              "schema": {
+                "type": "string",
+                "description": "Language",
+                "default": "en",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/WeatherRealTime"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/WeatherRealTime"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/WeatherRealTime"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/WeatherRealTime"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Weather/Measuringpoint": {
+        "get": {
+          "tags": [
+            "Weather"
+          ],
+          "summary": "GET Measuringpoint LIST",
+          "parameters": [
+            {
+              "name": "idlist",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "locfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "areafilter",
+              "in": "query",
+              "description": "Area ID (multiple IDs possible, separated by \",\")",
+              "schema": {
+                "type": "string",
+                "description": "Area ID (multiple IDs possible, separated by \",\")",
+                "nullable": true
+              }
+            },
+            {
+              "name": "skiareafilter",
+              "in": "query",
+              "description": "Skiarea ID",
+              "schema": {
+                "type": "string",
+                "description": "Skiarea ID",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "active",
+              "in": "query",
+              "schema": {
+                "type": "boolean",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhactive",
+              "in": "query",
+              "schema": {
+                "type": "boolean",
+                "nullable": true
+              }
+            },
+            {
+              "name": "lastchange",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "latitude",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Measuringpoint"
+                    }
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Measuringpoint"
+                    }
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Measuringpoint"
+                    }
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Measuringpoint"
+                    }
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Weather/Measuringpoint/{id}": {
+        "get": {
+          "tags": [
+            "Weather"
+          ],
+          "summary": "GET Measuringpoint SINGLE",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "Measuringpoint ID",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "Measuringpoint ID",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Measuringpoint"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Measuringpoint"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Measuringpoint"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Measuringpoint"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/Weather/SnowReport": {
+        "get": {
+          "tags": [
+            "Weather"
+          ],
+          "summary": "GET Snowreport Data LIVE",
+          "parameters": [
+            {
+              "name": "skiareaid",
+              "in": "query",
+              "description": "Skiarea ID",
+              "schema": {
+                "type": "string",
+                "description": "Skiarea ID",
+                "nullable": true
+              }
+            },
+            {
+              "name": "lang",
+              "in": "query",
+              "description": "Language",
+              "schema": {
+                "type": "string",
+                "description": "Language",
+                "default": "de",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SnowReportBaseData"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SnowReportBaseData"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SnowReportBaseData"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/SnowReportBaseData"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/WebcamInfo": {
+        "get": {
+          "tags": [
+            "WebcamInfo"
+          ],
+          "summary": "GET Webcam List",
+          "parameters": [
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "pagenumber",
+              "in": "query",
+              "description": "Pagenumber, (default:1)",
+              "schema": {
+                "type": "integer",
+                "description": "Pagenumber, (default:1)",
+                "format": "int32",
+                "default": 1
+              }
+            },
+            {
+              "name": "pagesize",
+              "in": "query",
+              "description": "Elements per Page (max 1024), (default:10)",
+              "schema": {
+                "type": "integer",
+                "description": "Elements per Page (max 1024), (default:10)",
+                "format": "int32",
+                "default": 25
+              }
+            },
+            {
+              "name": "source",
+              "in": "query",
+              "description": "Source Filter(String, ), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Source Filter(String, ), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "idlist",
+              "in": "query",
+              "description": "IDFilter (Separator ',' List of Gastronomy IDs), (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "IDFilter (Separator ',' List of Gastronomy IDs), (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "active",
+              "in": "query",
+              "description": "Active Webcam Filter (possible Values: 'true' only Active Gastronomies, 'false' only Disabled Gastronomies",
+              "schema": {
+                "type": "boolean",
+                "description": "Active Webcam Filter (possible Values: 'true' only Active Gastronomies, 'false' only Disabled Gastronomies",
+                "nullable": true
+              }
+            },
+            {
+              "name": "odhactive",
+              "in": "query",
+              "description": "ODH Active (refers to field SmgActive) (Published) Webcam Filter (possible Values: 'true' only published Webcam, 'false' only not published Webcam, (default:'null')",
+              "schema": {
+                "type": "boolean",
+                "description": "ODH Active (refers to field SmgActive) (Published) Webcam Filter (possible Values: 'true' only published Webcam, 'false' only not published Webcam, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "seed",
+              "in": "query",
+              "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, not provided disables Random Sorting, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Seed '1 - 10' for Random Sorting, '0' generates a Random Seed, not provided disables Random Sorting, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "latitude",
+              "in": "query",
+              "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Latitude Format: '46.624975', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "longitude",
+              "in": "query",
+              "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "GeoFilter Longitude Format: '11.369909', 'null' = disabled, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "radius",
+              "in": "query",
+              "description": "Radius to Search in KM. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+              "schema": {
+                "type": "string",
+                "description": "Radius to Search in KM. Only Object withhin the given point and radius are returned and sorted by distance. Random Sorting is disabled if the GeoFilter Informations are provided, (default:'null')",
+                "nullable": true
+              }
+            },
+            {
+              "name": "updatefrom",
+              "in": "query",
+              "description": "Date from Format (yyyy-MM-dd) (all Gastronomy with LastChange >= datefrom are passed), (default: null = disabled)",
+              "schema": {
+                "type": "string",
+                "description": "Date from Format (yyyy-MM-dd) (all Gastronomy with LastChange >= datefrom are passed), (default: null = disabled)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "searchfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawfilter",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            {
+              "name": "rawsort",
+              "in": "query",
+              "schema": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "List created",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/WebcamInfoJsonResult"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/WebcamInfoJsonResult"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/WebcamInfoJsonResult"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/WebcamInfoJsonResult"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Request Error",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Internal Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      },
+      "/api/WebcamInfo/{id}": {
+        "get": {
+          "tags": [
+            "WebcamInfo"
+          ],
+          "summary": "GET Webcam Single",
+          "operationId": "SingleWebcamInfo",
+          "parameters": [
+            {
+              "name": "id",
+              "in": "path",
+              "description": "ID of the Webcam",
+              "required": true,
+              "schema": {
+                "type": "string",
+                "description": "ID of the Webcam",
+                "nullable": true
+              }
+            },
+            {
+              "name": "language",
+              "in": "query",
+              "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+              "schema": {
+                "type": "string",
+                "description": "Language field selector, displays data and fields available in the selected language (default:'null' all languages are displayed)",
+                "nullable": true
+              }
+            },
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Select fields to display, More fields are indicated by separator ',' example fields=Id,Active,Shortname. Select also Dictionary fields, example Detail.de.Title, or Elements of Arrays example ImageGallery[0].ImageUrl. (default:'null' all fields are displayed)",
+                "nullable": true
+              }
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/WebcamInfo"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/WebcamInfo"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/WebcamInfo"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/WebcamInfo"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad Request",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                },
+                "text/csv": {
+                  "schema": {
+                    "$ref": "#/components/schemas/ProblemDetails"
+                  }
+                }
+              }
+            },
+            "500": {
+              "description": "Server Error"
+            }
+          },
+          "security": [
+            {
+              "oauth2": [ ]
+            }
+          ]
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "LicenseInfo": {
+          "type": "object",
+          "properties": {
+            "License": {
+              "type": "string",
+              "nullable": true
+            },
+            "LicenseHolder": {
+              "type": "string",
+              "nullable": true
+            },
+            "Author": {
+              "type": "string",
+              "nullable": true
+            },
+            "ClosedData": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "AccoFeature": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Name": {
+              "type": "string",
+              "nullable": true
+            },
+            "HgvId": {
+              "type": "string",
+              "nullable": true
+            },
+            "OtaCodes": {
+              "type": "string",
+              "nullable": true
+            },
+            "RoomAmenityCodes": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "AccoDetail": {
+          "type": "object",
+          "properties": {
+            "Language": {
+              "type": "string",
+              "nullable": true
+            },
+            "Name": {
+              "type": "string",
+              "nullable": true
+            },
+            "NameAddition": {
+              "type": "string",
+              "nullable": true
+            },
+            "Street": {
+              "type": "string",
+              "nullable": true
+            },
+            "Zip": {
+              "type": "string",
+              "nullable": true
+            },
+            "Phone": {
+              "type": "string",
+              "nullable": true
+            },
+            "Mobile": {
+              "type": "string",
+              "nullable": true
+            },
+            "Fax": {
+              "type": "string",
+              "nullable": true
+            },
+            "Firstname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Lastname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Email": {
+              "type": "string",
+              "nullable": true
+            },
+            "Website": {
+              "type": "string",
+              "nullable": true
+            },
+            "City": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortdesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "Longdesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "Vat": {
+              "type": "string",
+              "nullable": true
+            },
+            "CountryCode": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "AccoBookingChannel": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Pos1ID": {
+              "type": "string",
+              "nullable": true
+            },
+            "Portalname": {
+              "type": "string",
+              "nullable": true
+            },
+            "BookingId": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ImageGallery": {
+          "type": "object",
+          "properties": {
+            "ImageName": {
+              "type": "string",
+              "nullable": true
+            },
+            "ImageUrl": {
+              "type": "string",
+              "nullable": true
+            },
+            "Width": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Height": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "ImageSource": {
+              "type": "string",
+              "nullable": true
+            },
+            "ImageTitle": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "ImageDesc": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "ImageAltText": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "IsInGallery": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "ListPosition": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "ValidFrom": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "ValidTo": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "CopyRight": {
+              "type": "string",
+              "nullable": true
+            },
+            "License": {
+              "type": "string",
+              "nullable": true
+            },
+            "LicenseHolder": {
+              "type": "string",
+              "nullable": true
+            },
+            "ImageTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "RegionInfo": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Name": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "TvInfo": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Name": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "MunicipalityInfo": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Name": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DistrictInfo": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Name": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "AreaInfo": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Name": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "LocationInfo": {
+          "type": "object",
+          "properties": {
+            "RegionInfo": {
+              "$ref": "#/components/schemas/RegionInfo"
+            },
+            "TvInfo": {
+              "$ref": "#/components/schemas/TvInfo"
+            },
+            "MunicipalityInfo": {
+              "$ref": "#/components/schemas/MunicipalityInfo"
+            },
+            "DistrictInfo": {
+              "$ref": "#/components/schemas/DistrictInfo"
+            },
+            "AreaInfo": {
+              "$ref": "#/components/schemas/AreaInfo"
+            }
+          },
+          "additionalProperties": false
+        },
+        "RoomPictures": {
+          "type": "object",
+          "properties": {
+            "Pictureurl": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Bank": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string",
+              "nullable": true
+            },
+            "Iban": {
+              "type": "string",
+              "nullable": true
+            },
+            "Swift": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "PaymentTerm": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Methods": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Prepayment": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Ccards": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Priority": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Description": {
+              "type": "string",
+              "nullable": true
+            },
+            "Bank": {
+              "$ref": "#/components/schemas/Bank"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Penalty": {
+          "type": "object",
+          "properties": {
+            "Percent": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "Datefrom": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "Daysarrival": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "CancelPolicy": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Refundable": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "RefundableUntil": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "Description": {
+              "type": "string",
+              "nullable": true
+            },
+            "Penalties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Penalty"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "RoomDetails": {
+          "type": "object",
+          "properties": {
+            "RoomId": {
+              "type": "string",
+              "nullable": true
+            },
+            "RoomSeq": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "TotalPrice": {
+              "type": "number",
+              "format": "double"
+            },
+            "OfferId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Price_ws": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "Price_bb": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "Price_hb": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "Price_fb": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "Price_ai": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "Roomtype": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "Roomfree": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "Roommax": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "Roommin": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "Roomstd": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "Roomtitle": {
+              "type": "string",
+              "nullable": true
+            },
+            "Roomdesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "RoomChannelLink": {
+              "type": "string",
+              "nullable": true
+            },
+            "TotalPriceString": {
+              "type": "string",
+              "nullable": true
+            },
+            "RoomPictures": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RoomPictures"
+              },
+              "nullable": true
+            },
+            "PaymentTerm": {
+              "$ref": "#/components/schemas/PaymentTerm"
+            },
+            "CancelPolicy": {
+              "$ref": "#/components/schemas/CancelPolicy"
+            }
+          },
+          "additionalProperties": false
+        },
+        "MssResponseShort": {
+          "type": "object",
+          "properties": {
+            "HotelId": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "A0RID": {
+              "type": "string",
+              "nullable": true
+            },
+            "Bookable": {
+              "type": "boolean"
+            },
+            "ChannelID": {
+              "type": "string",
+              "nullable": true
+            },
+            "Channellink": {
+              "type": "string",
+              "nullable": true
+            },
+            "OfferId": {
+              "type": "string",
+              "nullable": true
+            },
+            "OfferGid": {
+              "type": "string",
+              "nullable": true
+            },
+            "OfferTyp": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "OfferShow": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "CheapestOffer": {
+              "type": "number",
+              "format": "double"
+            },
+            "CheapestOfferString": {
+              "type": "string",
+              "nullable": true
+            },
+            "OnlinepaymentMethods": {
+              "type": "string",
+              "nullable": true
+            },
+            "OnlinepaymentPrepayment": {
+              "type": "string",
+              "nullable": true
+            },
+            "OnlinepaymentCCards": {
+              "type": "string",
+              "nullable": true
+            },
+            "CheapestOffer_ws": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "CheapestOffer_bb": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "CheapestOffer_hb": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "CheapestOffer_fb": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "CheapestOffer_ai": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "RoomDetails": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RoomDetails"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "IndependentDescription": {
+          "type": "object",
+          "properties": {
+            "Language": {
+              "type": "string",
+              "nullable": true
+            },
+            "Description": {
+              "type": "string",
+              "nullable": true
+            },
+            "BacklinkUrl": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "IndependentData": {
+          "type": "object",
+          "properties": {
+            "IndependentDescription": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/IndependentDescription"
+              },
+              "nullable": true
+            },
+            "IndependentRating": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "Enabled": {
+              "type": "boolean",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "AccoRoomInfo": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Source": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Accommodation": {
+          "type": "object",
+          "properties": {
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "HgvId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Units": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Beds": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Representation": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "HasApartment": {
+              "type": "boolean"
+            },
+            "HasRoom": {
+              "type": "boolean"
+            },
+            "IsCamping": {
+              "type": "boolean"
+            },
+            "IsGastronomy": {
+              "type": "boolean"
+            },
+            "IsBookable": {
+              "type": "boolean"
+            },
+            "IsAccommodation": {
+              "type": "boolean"
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "TVMember": {
+              "type": "boolean"
+            },
+            "TourismVereinId": {
+              "type": "string",
+              "nullable": true
+            },
+            "MainLanguage": {
+              "type": "string",
+              "nullable": true
+            },
+            "FirstImport": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "Gpstype": {
+              "type": "string",
+              "nullable": true
+            },
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Altitude": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "AltitudeUnitofMeasure": {
+              "type": "string",
+              "nullable": true
+            },
+            "AccoCategoryId": {
+              "type": "string",
+              "nullable": true
+            },
+            "AccoTypeId": {
+              "type": "string",
+              "nullable": true
+            },
+            "DistrictId": {
+              "type": "string",
+              "nullable": true
+            },
+            "BoardIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "MarketingGroupIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "Features": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/AccoFeature"
+              },
+              "nullable": true
+            },
+            "BadgeIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "ThemeIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SpecialFeaturesIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "AccoDetail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/AccoDetail"
+              },
+              "nullable": true
+            },
+            "AccoBookingChannel": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/AccoBookingChannel"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "LocationInfo": {
+              "$ref": "#/components/schemas/LocationInfo"
+            },
+            "GastronomyId": {
+              "type": "string",
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "MssResponseShort": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/MssResponseShort"
+              },
+              "nullable": true
+            },
+            "IndependentData": {
+              "$ref": "#/components/schemas/IndependentData"
+            },
+            "AccoRoomInfo": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/AccoRoomInfo"
+              },
+              "nullable": true
+            },
+            "TrustYouID": {
+              "type": "string",
+              "nullable": true
+            },
+            "TrustYouScore": {
+              "type": "number",
+              "format": "double"
+            },
+            "TrustYouResults": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TrustYouActive": {
+              "type": "boolean"
+            },
+            "TrustYouState": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false
+        },
+        "AccommodationJsonResult": {
+          "type": "object",
+          "properties": {
+            "TotalResults": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TotalPages": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "CurrentPage": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "PreviousPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "NextPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "Seed": {
+              "type": "string",
+              "nullable": true
+            },
+            "Items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Accommodation"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ProblemDetails": {
+          "type": "object",
+          "properties": {
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "Title": {
+              "type": "string",
+              "nullable": true
+            },
+            "Status": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "Detail": {
+              "type": "string",
+              "nullable": true
+            },
+            "Instance": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": { }
+        },
+        "ArticleTypes": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Bitmask": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "Parent": {
+              "type": "string",
+              "nullable": true
+            },
+            "Key": {
+              "type": "string",
+              "nullable": true
+            },
+            "TypeDesc": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "GpsInfo": {
+          "type": "object",
+          "properties": {
+            "Gpstype": {
+              "type": "string",
+              "nullable": true
+            },
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Altitude": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "AltitudeUnitofMeasure": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "LTSTags": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Level": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TagName": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "OperationScheduleTime": {
+          "type": "object",
+          "properties": {
+            "Start": {
+              "type": "string",
+              "format": "date-span"
+            },
+            "End": {
+              "type": "string",
+              "format": "date-span"
+            },
+            "Monday": {
+              "type": "boolean"
+            },
+            "Tuesday": {
+              "type": "boolean"
+            },
+            "Wednesday": {
+              "type": "boolean"
+            },
+            "Thuresday": {
+              "type": "boolean"
+            },
+            "Friday": {
+              "type": "boolean"
+            },
+            "Saturday": {
+              "type": "boolean"
+            },
+            "Sunday": {
+              "type": "boolean"
+            },
+            "State": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Timecode": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false
+        },
+        "OperationSchedule": {
+          "type": "object",
+          "properties": {
+            "OperationscheduleName": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "Start": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "Stop": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "OperationScheduleTime": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/OperationScheduleTime"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "GpsTrack": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "GpxTrackDesc": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "GpxTrackUrl": {
+              "type": "string",
+              "nullable": true
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Detail": {
+          "type": "object",
+          "properties": {
+            "Header": {
+              "type": "string",
+              "nullable": true
+            },
+            "SubHeader": {
+              "type": "string",
+              "nullable": true
+            },
+            "IntroText": {
+              "type": "string",
+              "nullable": true
+            },
+            "BaseText": {
+              "type": "string",
+              "nullable": true
+            },
+            "Title": {
+              "type": "string",
+              "nullable": true
+            },
+            "AdditionalText": {
+              "type": "string",
+              "nullable": true
+            },
+            "MetaTitle": {
+              "type": "string",
+              "nullable": true
+            },
+            "MetaDesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "GetThereText": {
+              "type": "string",
+              "nullable": true
+            },
+            "Language": {
+              "type": "string",
+              "nullable": true
+            },
+            "Keywords": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ContactInfos": {
+          "type": "object",
+          "properties": {
+            "Address": {
+              "type": "string",
+              "nullable": true
+            },
+            "City": {
+              "type": "string",
+              "nullable": true
+            },
+            "ZipCode": {
+              "type": "string",
+              "nullable": true
+            },
+            "CountryCode": {
+              "type": "string",
+              "nullable": true
+            },
+            "CountryName": {
+              "type": "string",
+              "nullable": true
+            },
+            "Surname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Givenname": {
+              "type": "string",
+              "nullable": true
+            },
+            "NamePrefix": {
+              "type": "string",
+              "nullable": true
+            },
+            "Email": {
+              "type": "string",
+              "nullable": true
+            },
+            "Phonenumber": {
+              "type": "string",
+              "nullable": true
+            },
+            "Faxnumber": {
+              "type": "string",
+              "nullable": true
+            },
+            "Url": {
+              "type": "string",
+              "nullable": true
+            },
+            "Language": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyName": {
+              "type": "string",
+              "nullable": true
+            },
+            "Vat": {
+              "type": "string",
+              "nullable": true
+            },
+            "Tax": {
+              "type": "string",
+              "nullable": true
+            },
+            "LogoUrl": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "AdditionalPoiInfos": {
+          "type": "object",
+          "properties": {
+            "Novelty": {
+              "type": "string",
+              "nullable": true
+            },
+            "MainType": {
+              "type": "string",
+              "nullable": true
+            },
+            "SubType": {
+              "type": "string",
+              "nullable": true
+            },
+            "PoiType": {
+              "type": "string",
+              "nullable": true
+            },
+            "Language": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Ratings": {
+          "type": "object",
+          "properties": {
+            "Stamina": {
+              "type": "string",
+              "nullable": true
+            },
+            "Experience": {
+              "type": "string",
+              "nullable": true
+            },
+            "Landscape": {
+              "type": "string",
+              "nullable": true
+            },
+            "Difficulty": {
+              "type": "string",
+              "nullable": true
+            },
+            "Technique": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "GBLTSActivity": {
+          "type": "object",
+          "properties": {
+            "GpsPoints": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/GpsInfo"
+              },
+              "nullable": true
+            },
+            "LTSTags": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/LTSTags"
+              },
+              "nullable": true
+            },
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "OutdooractiveID": {
+              "type": "string",
+              "nullable": true
+            },
+            "OutdooractiveElevationID": {
+              "type": "string",
+              "nullable": true
+            },
+            "CopyrightChecked": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "SmgId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Highlight": {
+              "type": "boolean"
+            },
+            "Difficulty": {
+              "type": "string",
+              "nullable": true
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "SubType": {
+              "type": "string",
+              "nullable": true
+            },
+            "PoiType": {
+              "type": "string",
+              "nullable": true
+            },
+            "FirstImport": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "LocationInfo": {
+              "$ref": "#/components/schemas/LocationInfo"
+            },
+            "TourismorganizationId": {
+              "type": "string",
+              "nullable": true
+            },
+            "AreaId": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "AltitudeDifference": {
+              "type": "number",
+              "format": "double"
+            },
+            "AltitudeHighestPoint": {
+              "type": "number",
+              "format": "double"
+            },
+            "AltitudeLowestPoint": {
+              "type": "number",
+              "format": "double"
+            },
+            "AltitudeSumUp": {
+              "type": "number",
+              "format": "double"
+            },
+            "AltitudeSumDown": {
+              "type": "number",
+              "format": "double"
+            },
+            "DistanceDuration": {
+              "type": "number",
+              "format": "double"
+            },
+            "DistanceLength": {
+              "type": "number",
+              "format": "double"
+            },
+            "IsOpen": {
+              "type": "boolean"
+            },
+            "IsPrepared": {
+              "type": "boolean"
+            },
+            "RunToValley": {
+              "type": "boolean"
+            },
+            "IsWithLigth": {
+              "type": "boolean"
+            },
+            "HasRentals": {
+              "type": "boolean"
+            },
+            "HasFreeEntrance": {
+              "type": "boolean"
+            },
+            "LiftAvailable": {
+              "type": "boolean"
+            },
+            "FeetClimb": {
+              "type": "boolean"
+            },
+            "BikeTransport": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "OperationSchedule": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/OperationSchedule"
+              },
+              "nullable": true
+            },
+            "GpsInfo": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsInfo"
+              },
+              "nullable": true
+            },
+            "GpsTrack": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsTrack"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "AdditionalPoiInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/AdditionalPoiInfos"
+              },
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "Ratings": {
+              "$ref": "#/components/schemas/Ratings"
+            },
+            "Exposition": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "OwnerRid": {
+              "type": "string",
+              "nullable": true
+            },
+            "ChildPoiIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "MasterPoiIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "WayNumber": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "GBLTSActivityJsonResult": {
+          "type": "object",
+          "properties": {
+            "TotalResults": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TotalPages": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "CurrentPage": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "PreviousPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "NextPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "Seed": {
+              "type": "string",
+              "nullable": true
+            },
+            "Items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GBLTSActivity"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ActivityTypes": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Bitmask": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "Parent": {
+              "type": "string",
+              "nullable": true
+            },
+            "Key": {
+              "type": "string",
+              "nullable": true
+            },
+            "TypeDesc": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "AdditionalArticleInfos": {
+          "type": "object",
+          "properties": {
+            "Language": {
+              "type": "string",
+              "nullable": true
+            },
+            "Elements": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ArticleLinkInfo": {
+          "type": "object",
+          "properties": {
+            "Language": {
+              "type": "string",
+              "nullable": true
+            },
+            "Elements": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Article": {
+          "type": "object",
+          "properties": {
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Highlight": {
+              "type": "boolean"
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "SubType": {
+              "type": "string",
+              "nullable": true
+            },
+            "FirstImport": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "ArticleDate": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "ArticleDateTo": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "OperationSchedule": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/OperationSchedule"
+              },
+              "nullable": true
+            },
+            "GpsInfo": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsInfo"
+              },
+              "nullable": true
+            },
+            "GpsTrack": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsTrack"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "AdditionalArticleInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/AdditionalArticleInfos"
+              },
+              "nullable": true
+            },
+            "ArticleLinkInfo": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ArticleLinkInfo"
+              },
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ArticleJsonResult": {
+          "type": "object",
+          "properties": {
+            "TotalResults": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TotalPages": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "CurrentPage": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "PreviousPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "NextPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "Seed": {
+              "type": "string",
+              "nullable": true
+            },
+            "Items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Article"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DetailsThemed": {
+          "type": "object",
+          "properties": {
+            "Title": {
+              "type": "string",
+              "nullable": true
+            },
+            "Intro": {
+              "type": "string",
+              "nullable": true
+            },
+            "MetaTitle": {
+              "type": "string",
+              "nullable": true
+            },
+            "MetaDesc": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DetailThemed": {
+          "type": "object",
+          "properties": {
+            "DetailsThemed": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/DetailsThemed"
+              },
+              "nullable": true
+            },
+            "Language": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "GpsPolygon": {
+          "type": "object",
+          "properties": {
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Webcam": {
+          "type": "object",
+          "properties": {
+            "WebcamId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Webcamname": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "Webcamurl": {
+              "type": "string",
+              "nullable": true
+            },
+            "GpsInfo": {
+              "$ref": "#/components/schemas/GpsInfo"
+            },
+            "ListPosition": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "RelatedContent": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Name": {
+              "type": "string",
+              "nullable": true
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "Link": {
+              "type": "string",
+              "nullable": true,
+              "readOnly": true
+            },
+            "Self": {
+              "type": "string",
+              "nullable": true,
+              "readOnly": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "MetaRegion": {
+          "type": "object",
+          "properties": {
+            "DetailThemed": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/DetailThemed"
+              },
+              "nullable": true
+            },
+            "DistrictIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "TourismvereinIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "RegionIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "GpsPolygon": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsPolygon"
+              },
+              "nullable": true
+            },
+            "Webcam": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Webcam"
+              },
+              "nullable": true
+            },
+            "VisibleInSearch": {
+              "type": "boolean"
+            },
+            "RelatedContent": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RelatedContent"
+              },
+              "nullable": true
+            },
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "CustomId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Gpstype": {
+              "type": "string",
+              "nullable": true
+            },
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Altitude": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "AltitudeUnitofMeasure": {
+              "type": "string",
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "additionalProperties": false
+        },
+        "ExperienceArea": {
+          "type": "object",
+          "properties": {
+            "DistrictIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "TourismvereinIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "GpsPolygon": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsPolygon"
+              },
+              "nullable": true
+            },
+            "VisibleInSearch": {
+              "type": "boolean"
+            },
+            "RelatedContent": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RelatedContent"
+              },
+              "nullable": true
+            },
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "CustomId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Gpstype": {
+              "type": "string",
+              "nullable": true
+            },
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Altitude": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "AltitudeUnitofMeasure": {
+              "type": "string",
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Region": {
+          "type": "object",
+          "properties": {
+            "DetailThemed": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/DetailThemed"
+              },
+              "nullable": true
+            },
+            "GpsPolygon": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsPolygon"
+              },
+              "nullable": true
+            },
+            "Webcam": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Webcam"
+              },
+              "nullable": true
+            },
+            "VisibleInSearch": {
+              "type": "boolean"
+            },
+            "SkiareaIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "RelatedContent": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RelatedContent"
+              },
+              "nullable": true
+            },
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "CustomId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Gpstype": {
+              "type": "string",
+              "nullable": true
+            },
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Altitude": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "AltitudeUnitofMeasure": {
+              "type": "string",
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Tourismverein": {
+          "type": "object",
+          "properties": {
+            "RegionId": {
+              "type": "string",
+              "nullable": true
+            },
+            "GpsPolygon": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsPolygon"
+              },
+              "nullable": true
+            },
+            "Webcam": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Webcam"
+              },
+              "nullable": true
+            },
+            "VisibleInSearch": {
+              "type": "boolean"
+            },
+            "SkiareaIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "RelatedContent": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RelatedContent"
+              },
+              "nullable": true
+            },
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "CustomId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Gpstype": {
+              "type": "string",
+              "nullable": true
+            },
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Altitude": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "AltitudeUnitofMeasure": {
+              "type": "string",
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Municipality": {
+          "type": "object",
+          "properties": {
+            "Plz": {
+              "type": "string",
+              "nullable": true
+            },
+            "RegionId": {
+              "type": "string",
+              "nullable": true
+            },
+            "TourismvereinId": {
+              "type": "string",
+              "nullable": true
+            },
+            "SiagId": {
+              "type": "string",
+              "nullable": true
+            },
+            "GpsPolygon": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsPolygon"
+              },
+              "nullable": true
+            },
+            "Webcam": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Webcam"
+              },
+              "nullable": true
+            },
+            "VisibleInSearch": {
+              "type": "boolean"
+            },
+            "Inhabitants": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "IstatNumber": {
+              "type": "string",
+              "nullable": true
+            },
+            "RelatedContent": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RelatedContent"
+              },
+              "nullable": true
+            },
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "CustomId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Gpstype": {
+              "type": "string",
+              "nullable": true
+            },
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Altitude": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "AltitudeUnitofMeasure": {
+              "type": "string",
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "additionalProperties": false
+        },
+        "District": {
+          "type": "object",
+          "properties": {
+            "IsComune": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "RegionId": {
+              "type": "string",
+              "nullable": true
+            },
+            "TourismvereinId": {
+              "type": "string",
+              "nullable": true
+            },
+            "MunicipalityId": {
+              "type": "string",
+              "nullable": true
+            },
+            "SiagId": {
+              "type": "string",
+              "nullable": true
+            },
+            "GpsPolygon": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsPolygon"
+              },
+              "nullable": true
+            },
+            "Webcam": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Webcam"
+              },
+              "nullable": true
+            },
+            "VisibleInSearch": {
+              "type": "boolean"
+            },
+            "RelatedContent": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RelatedContent"
+              },
+              "nullable": true
+            },
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "CustomId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Gpstype": {
+              "type": "string",
+              "nullable": true
+            },
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Altitude": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "AltitudeUnitofMeasure": {
+              "type": "string",
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Area": {
+          "type": "object",
+          "properties": {
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "CustomId": {
+              "type": "string",
+              "nullable": true
+            },
+            "RegionId": {
+              "type": "string",
+              "nullable": true
+            },
+            "TourismvereinId": {
+              "type": "string",
+              "nullable": true
+            },
+            "MunicipalityId": {
+              "type": "string",
+              "nullable": true
+            },
+            "SkiAreaID": {
+              "type": "string",
+              "nullable": true
+            },
+            "GID": {
+              "type": "string",
+              "nullable": true
+            },
+            "LtsID": {
+              "type": "string",
+              "nullable": true
+            },
+            "AreaType": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "SkiRegion": {
+          "type": "object",
+          "properties": {
+            "GpsPolygon": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsPolygon"
+              },
+              "nullable": true
+            },
+            "Webcam": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Webcam"
+              },
+              "nullable": true
+            },
+            "RelatedContent": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RelatedContent"
+              },
+              "nullable": true
+            },
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "CustomId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Gpstype": {
+              "type": "string",
+              "nullable": true
+            },
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Altitude": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "AltitudeUnitofMeasure": {
+              "type": "string",
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "additionalProperties": false
+        },
+        "SkiArea": {
+          "type": "object",
+          "properties": {
+            "SkiRegionId": {
+              "type": "string",
+              "nullable": true
+            },
+            "SkiAreaMapURL": {
+              "type": "string",
+              "nullable": true
+            },
+            "TotalSlopeKm": {
+              "type": "string",
+              "nullable": true
+            },
+            "SlopeKmBlue": {
+              "type": "string",
+              "nullable": true
+            },
+            "SlopeKmRed": {
+              "type": "string",
+              "nullable": true
+            },
+            "SlopeKmBlack": {
+              "type": "string",
+              "nullable": true
+            },
+            "LiftCount": {
+              "type": "string",
+              "nullable": true
+            },
+            "AltitudeFrom": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "AltitudeTo": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "SkiRegionName": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "AreaId": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "Webcam": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Webcam"
+              },
+              "nullable": true
+            },
+            "LocationInfo": {
+              "$ref": "#/components/schemas/LocationInfo"
+            },
+            "OperationSchedule": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/OperationSchedule"
+              },
+              "nullable": true
+            },
+            "TourismvereinIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "RegionIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "GpsPolygon": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsPolygon"
+              },
+              "nullable": true
+            },
+            "RelatedContent": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RelatedContent"
+              },
+              "nullable": true
+            },
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "CustomId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Gpstype": {
+              "type": "string",
+              "nullable": true
+            },
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Altitude": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "AltitudeUnitofMeasure": {
+              "type": "string",
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Wine": {
+          "type": "object",
+          "properties": {
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "Vintage": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Awardyear": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "CustomId": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyId": {
+              "type": "string",
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "Awards": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "FirstImport": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Topic": {
+          "type": "object",
+          "properties": {
+            "TopicRID": {
+              "type": "string",
+              "nullable": true
+            },
+            "TopicInfo": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "EventPublisher": {
+          "type": "object",
+          "properties": {
+            "PublisherRID": {
+              "type": "string",
+              "nullable": true
+            },
+            "Ranc": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Publish": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false
+        },
+        "EventAdditionalInfos": {
+          "type": "object",
+          "properties": {
+            "Mplace": {
+              "type": "string",
+              "nullable": true
+            },
+            "Reg": {
+              "type": "string",
+              "nullable": true
+            },
+            "Location": {
+              "type": "string",
+              "nullable": true
+            },
+            "Language": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "EventPrice": {
+          "type": "object",
+          "properties": {
+            "Price": {
+              "type": "number",
+              "format": "double"
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "Pstd": {
+              "type": "string",
+              "nullable": true
+            },
+            "ShortDesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "Description": {
+              "type": "string",
+              "nullable": true
+            },
+            "Language": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "EventDate": {
+          "type": "object",
+          "properties": {
+            "From": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "To": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "SingleDays": {
+              "type": "boolean"
+            },
+            "MinPersons": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "MaxPersons": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Ticket": {
+              "type": "boolean"
+            },
+            "GpsNorth": {
+              "type": "number",
+              "format": "double"
+            },
+            "GpsEast": {
+              "type": "number",
+              "format": "double"
+            },
+            "Begin": {
+              "type": "string",
+              "format": "date-span"
+            },
+            "End": {
+              "type": "string",
+              "format": "date-span"
+            },
+            "Entrance": {
+              "type": "string",
+              "format": "date-span"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Event": {
+          "type": "object",
+          "properties": {
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "DateBegin": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "DateEnd": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "FirstImport": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "Gpstype": {
+              "type": "string",
+              "nullable": true
+            },
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Altitude": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "AltitudeUnitofMeasure": {
+              "type": "string",
+              "nullable": true
+            },
+            "OrgRID": {
+              "type": "string",
+              "nullable": true
+            },
+            "Ranc": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Ticket": {
+              "type": "string",
+              "nullable": true
+            },
+            "SignOn": {
+              "type": "string",
+              "nullable": true
+            },
+            "PayMet": {
+              "type": "string",
+              "nullable": true
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "DistrictId": {
+              "type": "string",
+              "nullable": true
+            },
+            "DistrictIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "TopicRIDs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "Topics": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Topic"
+              },
+              "nullable": true
+            },
+            "EventPublisher": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/EventPublisher"
+              },
+              "nullable": true
+            },
+            "EventAdditionalInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/EventAdditionalInfos"
+              },
+              "nullable": true
+            },
+            "EventPrice": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/EventPrice"
+              },
+              "nullable": true
+            },
+            "EventDate": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/EventDate"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "OrganizerInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "LocationInfo": {
+              "$ref": "#/components/schemas/LocationInfo"
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "EventJsonResult": {
+          "type": "object",
+          "properties": {
+            "TotalResults": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TotalPages": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "CurrentPage": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "PreviousPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "NextPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "Seed": {
+              "type": "string",
+              "nullable": true
+            },
+            "Items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Event"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "EventTypes": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Bitmask": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "TypeDesc": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "RoomBooked": {
+          "type": "object",
+          "properties": {
+            "Space": {
+              "type": "string",
+              "nullable": true
+            },
+            "SpaceDesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "SpaceAbbrev": {
+              "type": "string",
+              "nullable": true
+            },
+            "SpaceType": {
+              "type": "string",
+              "nullable": true
+            },
+            "Subtitle": {
+              "type": "string",
+              "nullable": true
+            },
+            "Comment": {
+              "type": "string",
+              "nullable": true
+            },
+            "StartDate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "EndDate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "StartDateUTC": {
+              "type": "number",
+              "format": "double"
+            },
+            "EndDateUTC": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "additionalProperties": false
+        },
+        "DocumentPDF": {
+          "type": "object",
+          "properties": {
+            "DocumentURL": {
+              "type": "string",
+              "nullable": true
+            },
+            "Language": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "EventShort": {
+          "type": "object",
+          "properties": {
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Source": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventLocation": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventId": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "EventDescription": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventDescriptionDE": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventDescriptionIT": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventDescriptionEN": {
+              "type": "string",
+              "nullable": true
+            },
+            "AnchorVenue": {
+              "type": "string",
+              "nullable": true
+            },
+            "AnchorVenueShort": {
+              "type": "string",
+              "nullable": true
+            },
+            "ChangedOn": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "StartDate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "EndDate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "StartDateUTC": {
+              "type": "number",
+              "format": "double"
+            },
+            "EndDateUTC": {
+              "type": "number",
+              "format": "double"
+            },
+            "WebAddress": {
+              "type": "string",
+              "nullable": true
+            },
+            "Display1": {
+              "type": "string",
+              "nullable": true
+            },
+            "Display2": {
+              "type": "string",
+              "nullable": true
+            },
+            "Display3": {
+              "type": "string",
+              "nullable": true
+            },
+            "Display4": {
+              "type": "string",
+              "nullable": true
+            },
+            "Display5": {
+              "type": "string",
+              "nullable": true
+            },
+            "Display6": {
+              "type": "string",
+              "nullable": true
+            },
+            "Display7": {
+              "type": "string",
+              "nullable": true
+            },
+            "Display8": {
+              "type": "string",
+              "nullable": true
+            },
+            "Display9": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyName": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyId": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyAddressLine1": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyAddressLine2": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyAddressLine3": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyPostalCode": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyCity": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyCountry": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyPhone": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyFax": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyMail": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyUrl": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactCode": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactFirstName": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactLastName": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactPhone": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactCell": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactFax": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactEmail": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactAddressLine1": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactAddressLine2": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactAddressLine3": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactPostalCode": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactCity": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactCountry": {
+              "type": "string",
+              "nullable": true
+            },
+            "RoomBooked": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RoomBooked"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "VideoUrl": {
+              "type": "string",
+              "nullable": true
+            },
+            "ActiveWeb": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "EventTextDE": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventTextIT": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventTextEN": {
+              "type": "string",
+              "nullable": true
+            },
+            "TechnologyFields": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "CustomTagging": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SoldOut": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "EventDocument": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DocumentPDF"
+              },
+              "nullable": true
+            },
+            "ExternalOrganizer": {
+              "type": "boolean",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "EventShortResult": {
+          "type": "object",
+          "properties": {
+            "TotalResults": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TotalPages": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "CurrentPage": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "OnlineResults": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "ResultId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Seed": {
+              "type": "string",
+              "nullable": true
+            },
+            "Items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/EventShort"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "EventShortByRoom": {
+          "type": "object",
+          "properties": {
+            "SpaceDescList": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SpaceDesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "SpaceType": {
+              "type": "string",
+              "nullable": true
+            },
+            "Subtitle": {
+              "type": "string",
+              "nullable": true
+            },
+            "RoomStartDate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "RoomEndDate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "RoomStartDateUTC": {
+              "type": "number",
+              "format": "double"
+            },
+            "RoomEndDateUTC": {
+              "type": "number",
+              "format": "double"
+            },
+            "EventId": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "EventDescription": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "EventDescriptionDE": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventDescriptionIT": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventDescriptionEN": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventAnchorVenue": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventAnchorVenueShort": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventStartDate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "EventEndDate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "EventStartDateUTC": {
+              "type": "number",
+              "format": "double"
+            },
+            "EventEndDateUTC": {
+              "type": "number",
+              "format": "double"
+            },
+            "EventWebAddress": {
+              "type": "string",
+              "nullable": true
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventSource": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventLocation": {
+              "type": "string",
+              "nullable": true
+            },
+            "CompanyName": {
+              "type": "string",
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "VideoUrl": {
+              "type": "string",
+              "nullable": true
+            },
+            "ActiveWeb": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "EventTextDE": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventTextIT": {
+              "type": "string",
+              "nullable": true
+            },
+            "EventTextEN": {
+              "type": "string",
+              "nullable": true
+            },
+            "TechnologyFields": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "CustomTagging": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SoldOut": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "EventDocument": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "ExternalOrganizer": {
+              "type": "boolean",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "CategoryCodes": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DishRates": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "MinAmount": {
+              "type": "number",
+              "format": "double"
+            },
+            "MaxAmount": {
+              "type": "number",
+              "format": "double"
+            },
+            "CurrencyCode": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "CapacityCeremony": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "MaxSeatingCapacity": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Facilities": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Gastronomy": {
+          "type": "object",
+          "properties": {
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "DistrictId": {
+              "type": "string",
+              "nullable": true
+            },
+            "FirstImport": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "Gpstype": {
+              "type": "string",
+              "nullable": true
+            },
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Altitude": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "AltitudeUnitofMeasure": {
+              "type": "string",
+              "nullable": true
+            },
+            "OperationSchedule": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/OperationSchedule"
+              },
+              "nullable": true
+            },
+            "MaxSeatingCapacity": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "CategoryCodes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CategoryCodes"
+              },
+              "nullable": true
+            },
+            "DishRates": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DishRates"
+              },
+              "nullable": true
+            },
+            "CapacityCeremony": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CapacityCeremony"
+              },
+              "nullable": true
+            },
+            "Facilities": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Facilities"
+              },
+              "nullable": true
+            },
+            "MarketinggroupId": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "LocationInfo": {
+              "$ref": "#/components/schemas/LocationInfo"
+            },
+            "AccommodationId": {
+              "type": "string",
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "RepresentationRestriction": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "GastronomyJsonResult": {
+          "type": "object",
+          "properties": {
+            "TotalResults": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TotalPages": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "CurrentPage": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "PreviousPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "NextPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "Seed": {
+              "type": "string",
+              "nullable": true
+            },
+            "Items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Gastronomy"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "GastronomyTypes": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Bitmask": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "Key": {
+              "type": "string",
+              "nullable": true
+            },
+            "TypeDesc": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "LocHelperclass": {
+          "type": "object",
+          "properties": {
+            "typ": {
+              "type": "string",
+              "nullable": true
+            },
+            "name": {
+              "type": "string",
+              "nullable": true
+            },
+            "id": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "PoiProperty": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string",
+              "nullable": true
+            },
+            "Value": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "AdditionalContact": {
+          "type": "object",
+          "properties": {
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "ContactInfos": {
+              "$ref": "#/components/schemas/ContactInfos"
+            },
+            "Description": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ODHActivityPoi": {
+          "type": "object",
+          "properties": {
+            "GpsPoints": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/GpsInfo"
+              },
+              "nullable": true
+            },
+            "CustomId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Webcam": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Webcam"
+              },
+              "nullable": true
+            },
+            "PoiProperty": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PoiProperty"
+                }
+              },
+              "nullable": true
+            },
+            "PoiServices": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "Source": {
+              "type": "string",
+              "nullable": true
+            },
+            "SyncSourceInterface": {
+              "type": "string",
+              "nullable": true
+            },
+            "SyncUpdateMode": {
+              "type": "string",
+              "nullable": true
+            },
+            "AgeFrom": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "AgeTo": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "MaxSeatingCapacity": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "CategoryCodes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CategoryCodes"
+              },
+              "nullable": true
+            },
+            "DishRates": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DishRates"
+              },
+              "nullable": true
+            },
+            "CapacityCeremony": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CapacityCeremony"
+              },
+              "nullable": true
+            },
+            "Facilities": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Facilities"
+              },
+              "nullable": true
+            },
+            "RelatedContent": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RelatedContent"
+              },
+              "nullable": true
+            },
+            "AdditionalContact": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AdditionalContact"
+                }
+              },
+              "nullable": true
+            },
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "OutdooractiveID": {
+              "type": "string",
+              "nullable": true
+            },
+            "OutdooractiveElevationID": {
+              "type": "string",
+              "nullable": true
+            },
+            "CopyrightChecked": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "SmgId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Highlight": {
+              "type": "boolean"
+            },
+            "Difficulty": {
+              "type": "string",
+              "nullable": true
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "SubType": {
+              "type": "string",
+              "nullable": true
+            },
+            "PoiType": {
+              "type": "string",
+              "nullable": true
+            },
+            "FirstImport": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "LocationInfo": {
+              "$ref": "#/components/schemas/LocationInfo"
+            },
+            "TourismorganizationId": {
+              "type": "string",
+              "nullable": true
+            },
+            "AreaId": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "AltitudeDifference": {
+              "type": "number",
+              "format": "double"
+            },
+            "AltitudeHighestPoint": {
+              "type": "number",
+              "format": "double"
+            },
+            "AltitudeLowestPoint": {
+              "type": "number",
+              "format": "double"
+            },
+            "AltitudeSumUp": {
+              "type": "number",
+              "format": "double"
+            },
+            "AltitudeSumDown": {
+              "type": "number",
+              "format": "double"
+            },
+            "DistanceDuration": {
+              "type": "number",
+              "format": "double"
+            },
+            "DistanceLength": {
+              "type": "number",
+              "format": "double"
+            },
+            "IsOpen": {
+              "type": "boolean"
+            },
+            "IsPrepared": {
+              "type": "boolean"
+            },
+            "RunToValley": {
+              "type": "boolean"
+            },
+            "IsWithLigth": {
+              "type": "boolean"
+            },
+            "HasRentals": {
+              "type": "boolean"
+            },
+            "HasFreeEntrance": {
+              "type": "boolean"
+            },
+            "LiftAvailable": {
+              "type": "boolean"
+            },
+            "FeetClimb": {
+              "type": "boolean"
+            },
+            "BikeTransport": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "OperationSchedule": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/OperationSchedule"
+              },
+              "nullable": true
+            },
+            "GpsInfo": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsInfo"
+              },
+              "nullable": true
+            },
+            "GpsTrack": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsTrack"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "AdditionalPoiInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/AdditionalPoiInfos"
+              },
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "Ratings": {
+              "$ref": "#/components/schemas/Ratings"
+            },
+            "Exposition": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "OwnerRid": {
+              "type": "string",
+              "nullable": true
+            },
+            "ChildPoiIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "MasterPoiIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "WayNumber": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ODHActivityPoiJsonResult": {
+          "type": "object",
+          "properties": {
+            "TotalResults": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TotalPages": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "CurrentPage": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "PreviousPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "NextPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "Seed": {
+              "type": "string",
+              "nullable": true
+            },
+            "Items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ODHActivityPoi"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "SmgPoiTypes": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Bitmask": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "Parent": {
+              "type": "string",
+              "nullable": true
+            },
+            "Key": {
+              "type": "string",
+              "nullable": true
+            },
+            "TypeDesc": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "SmgTags": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "TagName": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "ValidForEntity": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "MainEntity": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "GBLTSPoi": {
+          "type": "object",
+          "properties": {
+            "GpsPoints": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/GpsInfo"
+              },
+              "nullable": true
+            },
+            "LTSTags": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/LTSTags"
+              },
+              "nullable": true
+            },
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "OutdooractiveID": {
+              "type": "string",
+              "nullable": true
+            },
+            "OutdooractiveElevationID": {
+              "type": "string",
+              "nullable": true
+            },
+            "CopyrightChecked": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "SmgId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Highlight": {
+              "type": "boolean"
+            },
+            "Difficulty": {
+              "type": "string",
+              "nullable": true
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "SubType": {
+              "type": "string",
+              "nullable": true
+            },
+            "PoiType": {
+              "type": "string",
+              "nullable": true
+            },
+            "FirstImport": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "LocationInfo": {
+              "$ref": "#/components/schemas/LocationInfo"
+            },
+            "TourismorganizationId": {
+              "type": "string",
+              "nullable": true
+            },
+            "AreaId": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "AltitudeDifference": {
+              "type": "number",
+              "format": "double"
+            },
+            "AltitudeHighestPoint": {
+              "type": "number",
+              "format": "double"
+            },
+            "AltitudeLowestPoint": {
+              "type": "number",
+              "format": "double"
+            },
+            "AltitudeSumUp": {
+              "type": "number",
+              "format": "double"
+            },
+            "AltitudeSumDown": {
+              "type": "number",
+              "format": "double"
+            },
+            "DistanceDuration": {
+              "type": "number",
+              "format": "double"
+            },
+            "DistanceLength": {
+              "type": "number",
+              "format": "double"
+            },
+            "IsOpen": {
+              "type": "boolean"
+            },
+            "IsPrepared": {
+              "type": "boolean"
+            },
+            "RunToValley": {
+              "type": "boolean"
+            },
+            "IsWithLigth": {
+              "type": "boolean"
+            },
+            "HasRentals": {
+              "type": "boolean"
+            },
+            "HasFreeEntrance": {
+              "type": "boolean"
+            },
+            "LiftAvailable": {
+              "type": "boolean"
+            },
+            "FeetClimb": {
+              "type": "boolean"
+            },
+            "BikeTransport": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "OperationSchedule": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/OperationSchedule"
+              },
+              "nullable": true
+            },
+            "GpsInfo": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsInfo"
+              },
+              "nullable": true
+            },
+            "GpsTrack": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsTrack"
+              },
+              "nullable": true
+            },
+            "ImageGallery": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ImageGallery"
+              },
+              "nullable": true
+            },
+            "Detail": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/Detail"
+              },
+              "nullable": true
+            },
+            "ContactInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/ContactInfos"
+              },
+              "nullable": true
+            },
+            "AdditionalPoiInfos": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/components/schemas/AdditionalPoiInfos"
+              },
+              "nullable": true
+            },
+            "SmgTags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "Ratings": {
+              "$ref": "#/components/schemas/Ratings"
+            },
+            "Exposition": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "OwnerRid": {
+              "type": "string",
+              "nullable": true
+            },
+            "ChildPoiIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "MasterPoiIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "WayNumber": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "GBLTSPoiJsonResult": {
+          "type": "object",
+          "properties": {
+            "TotalResults": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TotalPages": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "CurrentPage": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "PreviousPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "NextPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "Seed": {
+              "type": "string",
+              "nullable": true
+            },
+            "Items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GBLTSPoi"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "PoiTypes": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Bitmask": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "Type": {
+              "type": "string",
+              "nullable": true
+            },
+            "Parent": {
+              "type": "string",
+              "nullable": true
+            },
+            "Key": {
+              "type": "string",
+              "nullable": true
+            },
+            "TypeDesc": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDMeta": {
+          "type": "object",
+          "properties": {
+            "lastUpdate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "dataProvider": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDLinks": {
+          "type": "object",
+          "properties": {
+            "self": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDGeometry": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "nullable": true
+            },
+            "coordinates": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "double"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDContactpoint": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "nullable": true
+            },
+            "telephone": {
+              "type": "string",
+              "nullable": true
+            },
+            "address": {
+              "$ref": "#/components/schemas/DDAddress"
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDAddress": {
+          "type": "object",
+          "properties": {
+            "street": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "city": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "region": {
+              "type": "string",
+              "nullable": true
+            },
+            "country": {
+              "type": "string",
+              "nullable": true
+            },
+            "complement": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "zipcode": {
+              "type": "string",
+              "nullable": true
+            },
+            "contactPoint": {
+              "$ref": "#/components/schemas/DDContactpoint"
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDOpeningTimes": {
+          "type": "object",
+          "properties": {
+            "opens": {
+              "type": "string",
+              "nullable": true
+            },
+            "closes": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDOpeninghoursweekly": {
+          "type": "object",
+          "properties": {
+            "validFrom": {
+              "type": "string",
+              "nullable": true
+            },
+            "validTo": {
+              "type": "string",
+              "nullable": true
+            },
+            "monday": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDOpeningTimes"
+              },
+              "nullable": true
+            },
+            "tuesday": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDOpeningTimes"
+              },
+              "nullable": true
+            },
+            "wednesday": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDOpeningTimes"
+              },
+              "nullable": true
+            },
+            "thursday": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDOpeningTimes"
+              },
+              "nullable": true
+            },
+            "friday": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDOpeningTimes"
+              },
+              "nullable": true
+            },
+            "saturday": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDOpeningTimes"
+              },
+              "nullable": true
+            },
+            "sunday": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDOpeningTimes"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDOpeninghours": {
+          "type": "object",
+          "properties": {
+            "weeklySchedules": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDOpeninghoursweekly"
+              },
+              "nullable": true
+            },
+            "dailySchedules": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DDOpeningTimes"
+                }
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDAttributes": {
+          "type": "object",
+          "properties": {
+            "abstract": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "description": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "geometries": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDGeometry"
+              },
+              "nullable": true
+            },
+            "howToArrive": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "name": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "shortName": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "url": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "address": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDAddress"
+              },
+              "nullable": true
+            },
+            "openingHours": {
+              "$ref": "#/components/schemas/DDOpeninghours"
+            },
+            "beds": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDAttributesMultimedia": {
+          "type": "object",
+          "properties": {
+            "abstract": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "contentType": {
+              "type": "string",
+              "nullable": true
+            },
+            "url": {
+              "type": "string",
+              "nullable": true
+            },
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "description": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "duration": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "height": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "license": {
+              "type": "string",
+              "nullable": true
+            },
+            "name": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "shortName": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "width": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDCopyrightownerData": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "nullable": true
+            },
+            "id": {
+              "type": "string",
+              "nullable": true
+            },
+            "attributes": {
+              "$ref": "#/components/schemas/DDAttributesMultimedia"
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDLinksRelated": {
+          "type": "object",
+          "properties": {
+            "related": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDCopyrightowner": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "$ref": "#/components/schemas/DDCopyrightownerData"
+            },
+            "links": {
+              "$ref": "#/components/schemas/DDLinksRelated"
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDRelationshipsMultiMedia": {
+          "type": "object",
+          "properties": {
+            "copyrightOwner": {
+              "$ref": "#/components/schemas/DDCopyrightowner"
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDMultimediadescriptions": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "nullable": true
+            },
+            "id": {
+              "type": "string",
+              "nullable": true
+            },
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "attributes": {
+              "$ref": "#/components/schemas/DDAttributesMultimedia"
+            },
+            "links": {
+              "$ref": "#/components/schemas/DDLinks"
+            },
+            "relationships": {
+              "$ref": "#/components/schemas/DDRelationshipsMultiMedia"
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDAvailablesetup": {
+          "type": "object",
+          "properties": {
+            "setup": {
+              "type": "string",
+              "nullable": true
+            },
+            "capacity": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDDimension": {
+          "type": "object",
+          "properties": {
+            "squareMeters": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "doorHeight": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "doorWidth": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "height": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "length": {
+              "type": "number",
+              "format": "float"
+            },
+            "width": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDAttributesSubVenues": {
+          "type": "object",
+          "properties": {
+            "availableSetups": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDAvailablesetup"
+              },
+              "nullable": true
+            },
+            "dimension": {
+              "$ref": "#/components/schemas/DDDimension"
+            },
+            "abstract": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "description": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "geometries": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDGeometry"
+              },
+              "nullable": true
+            },
+            "howToArrive": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "name": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "shortName": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "url": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "address": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDAddress"
+              },
+              "nullable": true
+            },
+            "openingHours": {
+              "$ref": "#/components/schemas/DDOpeninghours"
+            },
+            "beds": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ODHTags": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Self": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "VenueType": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "VenueCode": {
+              "type": "string",
+              "nullable": true
+            },
+            "Self": {
+              "type": "string",
+              "nullable": true,
+              "readOnly": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "VenueSetup": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Capacity": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "VenueCode": {
+              "type": "string",
+              "nullable": true
+            },
+            "Self": {
+              "type": "string",
+              "nullable": true,
+              "readOnly": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "VenueRoomDetails": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "SquareMeters": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Indoor": {
+              "type": "boolean"
+            },
+            "VenueFeatures": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/VenueType"
+              },
+              "nullable": true
+            },
+            "VenueSetup": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/VenueSetup"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "ODHData": {
+          "type": "object",
+          "properties": {
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "ODHActive": {
+              "type": "boolean"
+            },
+            "ODHTags": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/ODHTags"
+              },
+              "nullable": true
+            },
+            "LocationInfo": {
+              "$ref": "#/components/schemas/LocationInfo"
+            },
+            "HasLanguage": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "VenueCategory": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/VenueType"
+              },
+              "nullable": true
+            },
+            "GpsInfo": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/GpsInfo"
+              },
+              "nullable": true
+            },
+            "Source": {
+              "type": "string",
+              "nullable": true
+            },
+            "SyncSourceInterface": {
+              "type": "string",
+              "nullable": true
+            },
+            "RoomCount": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            },
+            "RoomDetails": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/VenueRoomDetails"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDSubVenue": {
+          "type": "object",
+          "properties": {
+            "attributes": {
+              "$ref": "#/components/schemas/DDAttributesSubVenues"
+            },
+            "type": {
+              "type": "string",
+              "nullable": true
+            },
+            "id": {
+              "type": "string",
+              "nullable": true
+            },
+            "meta": {
+              "$ref": "#/components/schemas/DDMeta"
+            },
+            "links": {
+              "$ref": "#/components/schemas/DDLinks"
+            },
+            "relationships": {
+              "$ref": "#/components/schemas/DDRelationships"
+            },
+            "odhdata": {
+              "$ref": "#/components/schemas/ODHData"
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDRelationships": {
+          "type": "object",
+          "properties": {
+            "multimediaDescriptions": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/DDMultimediadescriptions"
+                }
+              },
+              "nullable": true
+            },
+            "subVenues": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDSubVenue"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDVenue": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "nullable": true
+            },
+            "id": {
+              "type": "string",
+              "nullable": true
+            },
+            "meta": {
+              "$ref": "#/components/schemas/DDMeta"
+            },
+            "links": {
+              "$ref": "#/components/schemas/DDLinks"
+            },
+            "attributes": {
+              "$ref": "#/components/schemas/DDAttributes"
+            },
+            "relationships": {
+              "$ref": "#/components/schemas/DDRelationships"
+            },
+            "odhdata": {
+              "$ref": "#/components/schemas/ODHData"
+            }
+          },
+          "additionalProperties": false
+        },
+        "DDVenueJsonResult": {
+          "type": "object",
+          "properties": {
+            "TotalResults": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TotalPages": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "CurrentPage": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "PreviousPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "NextPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "Seed": {
+              "type": "string",
+              "nullable": true
+            },
+            "Items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DDVenue"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Conditions": {
+          "type": "object",
+          "properties": {
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "Title": {
+              "type": "string",
+              "nullable": true
+            },
+            "WeatherCondition": {
+              "type": "string",
+              "nullable": true
+            },
+            "WeatherImgurl": {
+              "type": "string",
+              "nullable": true
+            },
+            "Temperatures": {
+              "type": "string",
+              "nullable": true
+            },
+            "Weatherdesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "Reliability": {
+              "type": "string",
+              "nullable": true
+            },
+            "TempMaxmax": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TempMaxmin": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TempMinmax": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TempMinmin": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "bulletinStatus": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Forecast": {
+          "type": "object",
+          "properties": {
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "TempMaxmax": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TempMaxmin": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TempMinmax": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TempMinmin": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Weatherdesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "Weathercode": {
+              "type": "string",
+              "nullable": true
+            },
+            "WeatherImgurl": {
+              "type": "string",
+              "nullable": true
+            },
+            "Reliability": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Mountain": {
+          "type": "object",
+          "properties": {
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "Title": {
+              "type": "string",
+              "nullable": true
+            },
+            "Conditions": {
+              "type": "string",
+              "nullable": true
+            },
+            "Weatherdesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "Zerolimit": {
+              "type": "string",
+              "nullable": true
+            },
+            "MountainImgurl": {
+              "type": "string",
+              "nullable": true
+            },
+            "Reliability": {
+              "type": "string",
+              "nullable": true
+            },
+            "Sunrise": {
+              "type": "string",
+              "nullable": true
+            },
+            "Sunset": {
+              "type": "string",
+              "nullable": true
+            },
+            "Moonrise": {
+              "type": "string",
+              "nullable": true
+            },
+            "Moonset": {
+              "type": "string",
+              "nullable": true
+            },
+            "Northcode": {
+              "type": "string",
+              "nullable": true
+            },
+            "Northdesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "Northimgurl": {
+              "type": "string",
+              "nullable": true
+            },
+            "Southcode": {
+              "type": "string",
+              "nullable": true
+            },
+            "Southdesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "Southimgurl": {
+              "type": "string",
+              "nullable": true
+            },
+            "Temp1000": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Temp2000": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Temp3000": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Temp4000": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Windcode": {
+              "type": "string",
+              "nullable": true
+            },
+            "Winddesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "WindImgurl": {
+              "type": "string",
+              "nullable": true
+            },
+            "Snowlimit": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Stationdata": {
+          "type": "object",
+          "properties": {
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "Id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "CityName": {
+              "type": "string",
+              "nullable": true
+            },
+            "WeatherCode": {
+              "type": "string",
+              "nullable": true
+            },
+            "WeatherDesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "WeatherImgUrl": {
+              "type": "string",
+              "nullable": true
+            },
+            "MinTemp": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Maxtemp": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "MaxTemp": {
+              "type": "integer",
+              "format": "int32",
+              "readOnly": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Weather": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "evolutiontitle": {
+              "type": "string",
+              "nullable": true
+            },
+            "evolution": {
+              "type": "string",
+              "nullable": true
+            },
+            "Conditions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Conditions"
+              },
+              "nullable": true
+            },
+            "Forecast": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Forecast"
+              },
+              "nullable": true
+            },
+            "Mountain": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Mountain"
+              },
+              "nullable": true
+            },
+            "Stationdata": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Stationdata"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "BezirksForecast": {
+          "type": "object",
+          "properties": {
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "WeatherCode": {
+              "type": "string",
+              "nullable": true
+            },
+            "WeatherDesc": {
+              "type": "string",
+              "nullable": true
+            },
+            "WeatherImgUrl": {
+              "type": "string",
+              "nullable": true
+            },
+            "MaxTemp": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "MinTemp": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Freeze": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "RainFrom": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "RainTo": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Part1": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Part2": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Part3": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Part4": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "Thunderstorm": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "additionalProperties": false
+        },
+        "BezirksWeather": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "DistrictName": {
+              "type": "string",
+              "nullable": true
+            },
+            "date": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "TourismVereinIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "BezirksForecast": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/BezirksForecast"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "RealTimeMeasurements": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "type": "string",
+              "nullable": true
+            },
+            "description": {
+              "type": "string",
+              "nullable": true
+            },
+            "imageUrl": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "WeatherRealTime": {
+          "type": "object",
+          "properties": {
+            "altitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "categoryId": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "code": {
+              "type": "string",
+              "nullable": true
+            },
+            "id": {
+              "type": "string",
+              "nullable": true
+            },
+            "dd": {
+              "type": "string",
+              "nullable": true
+            },
+            "ff": {
+              "type": "string",
+              "nullable": true
+            },
+            "hs": {
+              "type": "string",
+              "nullable": true
+            },
+            "lastUpdated": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "lwdType": {
+              "type": "string",
+              "nullable": true
+            },
+            "n": {
+              "type": "string",
+              "nullable": true
+            },
+            "name": {
+              "type": "string",
+              "nullable": true
+            },
+            "p": {
+              "type": "string",
+              "nullable": true
+            },
+            "q": {
+              "type": "string",
+              "nullable": true
+            },
+            "rh": {
+              "type": "string",
+              "nullable": true
+            },
+            "t": {
+              "type": "string",
+              "nullable": true
+            },
+            "vaxcode": {
+              "type": "string",
+              "nullable": true
+            },
+            "w": {
+              "type": "string",
+              "nullable": true
+            },
+            "wmax": {
+              "type": "string",
+              "nullable": true
+            },
+            "sd": {
+              "type": "string",
+              "nullable": true
+            },
+            "visibility": {
+              "type": "string",
+              "nullable": true
+            },
+            "zoomLevel": {
+              "type": "string",
+              "nullable": true
+            },
+            "measurements": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RealTimeMeasurements"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "WeatherObservation": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Level": {
+              "type": "string",
+              "nullable": true
+            },
+            "LevelId": {
+              "type": "string",
+              "nullable": true
+            },
+            "WeatherStatus": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "IconID": {
+              "type": "string",
+              "nullable": true
+            },
+            "Date": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Measuringpoint": {
+          "type": "object",
+          "properties": {
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "FirstImport": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "LastUpdate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "Active": {
+              "type": "boolean"
+            },
+            "SmgActive": {
+              "type": "boolean"
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Gpstype": {
+              "type": "string",
+              "nullable": true
+            },
+            "Latitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Longitude": {
+              "type": "number",
+              "format": "double"
+            },
+            "Altitude": {
+              "type": "number",
+              "format": "double",
+              "nullable": true
+            },
+            "AltitudeUnitofMeasure": {
+              "type": "string",
+              "nullable": true
+            },
+            "SnowHeight": {
+              "type": "string",
+              "nullable": true
+            },
+            "newSnowHeight": {
+              "type": "string",
+              "nullable": true
+            },
+            "Temperature": {
+              "type": "string",
+              "nullable": true
+            },
+            "LastSnowDate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "WeatherObservation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/WeatherObservation"
+              },
+              "nullable": true
+            },
+            "LocationInfo": {
+              "$ref": "#/components/schemas/LocationInfo"
+            },
+            "OwnerId": {
+              "type": "string",
+              "nullable": true
+            },
+            "AreaIds": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "MeasuringpointReduced": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "LastUpdate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "SnowHeight": {
+              "type": "string",
+              "nullable": true
+            },
+            "newSnowHeight": {
+              "type": "string",
+              "nullable": true
+            },
+            "Temperature": {
+              "type": "string",
+              "nullable": true
+            },
+            "LastSnowDate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "WeatherObservation": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/WeatherObservation"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "SnowReportBaseData": {
+          "type": "object",
+          "properties": {
+            "Id": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "RID": {
+              "type": "string",
+              "nullable": true
+            },
+            "Skiregion": {
+              "type": "string",
+              "nullable": true
+            },
+            "Areaname": {
+              "type": "string",
+              "nullable": true
+            },
+            "LastUpdate": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "lang": {
+              "type": "string",
+              "nullable": true
+            },
+            "SkiAreaSlopeKm": {
+              "type": "string",
+              "nullable": true
+            },
+            "SkiMapUrl": {
+              "type": "string",
+              "nullable": true
+            },
+            "Measuringpoints": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/MeasuringpointReduced"
+              },
+              "nullable": true
+            },
+            "WebcamUrl": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "totalskilift": {
+              "type": "string",
+              "nullable": true
+            },
+            "openskilift": {
+              "type": "string",
+              "nullable": true
+            },
+            "totalskiliftkm": {
+              "type": "string",
+              "nullable": true
+            },
+            "openskiliftkm": {
+              "type": "string",
+              "nullable": true
+            },
+            "totalskislopes": {
+              "type": "string",
+              "nullable": true
+            },
+            "openskislopes": {
+              "type": "string",
+              "nullable": true
+            },
+            "totalskislopeskm": {
+              "type": "string",
+              "nullable": true
+            },
+            "openskislopeskm": {
+              "type": "string",
+              "nullable": true
+            },
+            "totaltracks": {
+              "type": "string",
+              "nullable": true
+            },
+            "opentracks": {
+              "type": "string",
+              "nullable": true
+            },
+            "totaltrackskm": {
+              "type": "string",
+              "nullable": true
+            },
+            "opentrackskm": {
+              "type": "string",
+              "nullable": true
+            },
+            "totalslides": {
+              "type": "string",
+              "nullable": true
+            },
+            "opentslides": {
+              "type": "string",
+              "nullable": true
+            },
+            "totalslideskm": {
+              "type": "string",
+              "nullable": true
+            },
+            "opentslideskm": {
+              "type": "string",
+              "nullable": true
+            },
+            "totaliceskating": {
+              "type": "string",
+              "nullable": true
+            },
+            "openiceskating": {
+              "type": "string",
+              "nullable": true
+            },
+            "contactadress": {
+              "type": "string",
+              "nullable": true
+            },
+            "contacttel": {
+              "type": "string",
+              "nullable": true
+            },
+            "contactcap": {
+              "type": "string",
+              "nullable": true
+            },
+            "contactcity": {
+              "type": "string",
+              "nullable": true
+            },
+            "contactfax": {
+              "type": "string",
+              "nullable": true
+            },
+            "contactweburl": {
+              "type": "string",
+              "nullable": true
+            },
+            "contactmail": {
+              "type": "string",
+              "nullable": true
+            },
+            "contactlogo": {
+              "type": "string",
+              "nullable": true
+            },
+            "contactgpsnorth": {
+              "type": "string",
+              "nullable": true
+            },
+            "contactgpseast": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "WebcamInfo": {
+          "type": "object",
+          "properties": {
+            "LicenseInfo": {
+              "$ref": "#/components/schemas/LicenseInfo"
+            },
+            "Id": {
+              "type": "string",
+              "nullable": true
+            },
+            "Streamurl": {
+              "type": "string",
+              "nullable": true
+            },
+            "Previewurl": {
+              "type": "string",
+              "nullable": true
+            },
+            "LastChange": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "FirstImport": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "Shortname": {
+              "type": "string",
+              "nullable": true
+            },
+            "Active": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "SmgActive": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "Source": {
+              "type": "string",
+              "nullable": true
+            },
+            "WebcamId": {
+              "type": "string",
+              "nullable": true
+            },
+            "Webcamname": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "Webcamurl": {
+              "type": "string",
+              "nullable": true
+            },
+            "GpsInfo": {
+              "$ref": "#/components/schemas/GpsInfo"
+            },
+            "ListPosition": {
+              "type": "integer",
+              "format": "int32",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "WebcamInfoJsonResult": {
+          "type": "object",
+          "properties": {
+            "TotalResults": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "TotalPages": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "CurrentPage": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "PreviousPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "NextPage": {
+              "type": "string",
+              "nullable": true
+            },
+            "Seed": {
+              "type": "string",
+              "nullable": true
+            },
+            "Items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/WebcamInfo"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "securitySchemes": {
+        "oauth2": {
+          "type": "oauth2",
+          "flows": {
+            "password": {
+              "tokenUrl": "https://auth.opendatahub.testingmachine.eu/auth/realms/noi/protocol/openid-connect/token",
+              "scopes": { }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/tests/SwaggerProvider.ProviderTests/SwaggerProvider.ProviderTests.fsproj
+++ b/tests/SwaggerProvider.ProviderTests/SwaggerProvider.ProviderTests.fsproj
@@ -22,6 +22,7 @@
     <Compile Include="v2\Swagger.Namespaces.Tests.fs" />
     <Compile Include="v2\Swagger.Slack.Tests.fs" />
     <Compile Include="v3\Swagger.PetStore.Tests.fs" />
+    <Compile Include="v3\Swagger.I0173.Tests.fs" />
     <Compile Include="v3\Swashbuckle.ReturnControllers.Tests.fs" />
     <Compile Include="v3\Swashbuckle.UpdateControllers.Tests.fs" />
     <Compile Include="v3\Swashbuckle.ResourceControllers.Tests.fs" />

--- a/tests/SwaggerProvider.ProviderTests/v3/Swagger.I0173.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/v3/Swagger.I0173.Tests.fs
@@ -1,0 +1,8 @@
+module Swagger.I0173.Tests
+
+open SwaggerProvider
+
+let [<Literal>] Schema = __SOURCE_DIRECTORY__ + "/../Schemas/v3/issue173.json"
+type OdhApiTourism  = OpenApiClientProvider<Schema>
+
+let inst = OdhApiTourism.Client()

--- a/tests/SwaggerProvider.ProviderTests/v3/Swashbuckle.ReturnControllers.Tests.fs
+++ b/tests/SwaggerProvider.ProviderTests/v3/Swashbuckle.ReturnControllers.Tests.fs
@@ -1,4 +1,4 @@
-﻿module Swashbuckle.v3.ReturnControllersTests
+module Swashbuckle.v3.ReturnControllersTests
 
 open Expecto
 open SwaggerProvider
@@ -169,5 +169,18 @@ let returnControllersTests =
         let! file = api.PostApiReturnFileDescription()
         file.Name  |> shouldEqual ("1.txt")
         file.Bytes  |> shouldEqual ([|1uy;2uy;3uy|])
+    }
+
+    testCaseAsync "Return String Dictionary GET Test" <| async {
+        let! dict = api.GetApiReturnStringDictionary()
+        dict |> shouldEqual (Map ["hello", "world"])
+    }
+
+    testCaseAsync "Return Object Point Dictionary GET Test" <| async {
+        let! dict = api.GetApiReturnObjectPointClassDictionary()
+        dict.ContainsKey "point" |> shouldEqual true
+        let point = dict.["point"]
+        point.X  |> shouldEqual (Some 0)
+        point.Y  |> shouldEqual (Some 0)
     }
   ]

--- a/tests/SwaggerProvider.Tests/v2/Schema.DefinitionsTests.fs
+++ b/tests/SwaggerProvider.Tests/v2/Schema.DefinitionsTests.fs
@@ -105,4 +105,22 @@ let definitionsTests =
             }
         }"""
         |> shouldBeEqual (Array String)
+
+    testCase "parse map of definitions" <| fun _ ->
+        """{
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/definitions/Tag"
+            }
+        }"""
+        |> shouldBeEqual (Dictionary (Reference "#/definitions/Tag"))
+
+    testCase "parse map of string" <| fun _ ->
+        """{
+            "type": "object",
+            "additionalProperties": {
+                "type": "string"
+            }
+        }"""
+        |> shouldBeEqual (Dictionary String)
   ]

--- a/tests/SwaggerProvider.Tests/v2/Schema.Spec.Json.Tests.fs
+++ b/tests/SwaggerProvider.Tests/v2/Schema.Spec.Json.Tests.fs
@@ -923,4 +923,31 @@ let jsonSpecTests =
                     }
                 |] |> Map.ofArray)
             Expect.equal actual expected "parse Responses Definitions Object"
+
+    testCase "Parameter Map Examples: Body Parameters Map" <| fun _ ->
+        """{
+          "name": "user",
+          "in": "body",
+          "description": "user to add to the system",
+          "required": true,
+          "schema": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }"""
+        |> SwaggerParser.parseJson
+        |> Parsers.parseParameterObject Parsers.emptyDict
+        |> fun actual ->
+            let expected =
+                {
+                    Name = "user"
+                    In = Body
+                    Description = "user to add to the system"
+                    Required = true
+                    Type = Dictionary String
+                    CollectionFormat = Csv
+                }
+            Expect.equal actual expected "parse body params array"
     ]

--- a/tests/Swashbuckle.WebApi.Server/Controllers/ReturnControllers.fs
+++ b/tests/Swashbuckle.WebApi.Server/Controllers/ReturnControllers.fs
@@ -1,4 +1,4 @@
-﻿namespace Swashbuckle.WebApi.Server.Controllers
+namespace Swashbuckle.WebApi.Server.Controllers
 
 open System
 open Microsoft.AspNetCore.Mvc
@@ -59,3 +59,9 @@ type ReturnObjectPointClassController () =
 
 type ReturnFileDescriptionController () =
     inherit ReturnController<Types.FileDescription>(Types.FileDescription("1.txt",[|1uy;2uy;3uy|]))
+
+type ReturnMapController () =
+    inherit ReturnController<Map<string, string>>(Map ["hello","world"])
+
+type ReturnMapObjectController () =
+    inherit ReturnController<Map<string, Types.PointClass>>(Map ["pt",Types.PointClass(0,0)])

--- a/tests/Swashbuckle.WebApi.Server/Controllers/ReturnControllers.fs
+++ b/tests/Swashbuckle.WebApi.Server/Controllers/ReturnControllers.fs
@@ -60,8 +60,8 @@ type ReturnObjectPointClassController () =
 type ReturnFileDescriptionController () =
     inherit ReturnController<Types.FileDescription>(Types.FileDescription("1.txt",[|1uy;2uy;3uy|]))
 
-type ReturnMapController () =
+type ReturnStringDictionaryController () =
     inherit ReturnController<Map<string, string>>(Map ["hello","world"])
 
-type ReturnMapObjectController () =
-    inherit ReturnController<Map<string, Types.PointClass>>(Map ["pt",Types.PointClass(0,0)])
+type ReturnObjectPointClassDictionaryController () =
+    inherit ReturnController<Map<string, Types.PointClass>>(Map ["point",Types.PointClass(0,0)])


### PR DESCRIPTION
Closes: #173 

The unit tests for the dictionary on the pet store sample are working, but I fear the schema of the pet store app is a bit "simple" compared to a production size schema.

I had no luck when running the provider on the following schema: https://api.tourism.testingmachine.eu/swagger/v1/swagger.json

```
error FS3033: The type provider 'SwaggerProvider.OpenApiClientTypeProvider' reported an error:
Cannot compile object 'ODHActivityPoi_PoiProperty_Item' based on unresolved reference '#/components/schemas/PoiProperty'
```

Did I something wrong in the implementation?