### PR TITLE
use DateOnly when string with `format: date` used

### DIFF
--- a/src/SwaggerProvider.DesignTime/v3/DefinitionCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/v3/DefinitionCompiler.fs
@@ -411,7 +411,13 @@ type DefinitionCompiler(schema: OpenApiDocument, provideNullable) as this =
                 | "string", "binary" // for `application/octet-stream` request body
                 | "file", _ -> // for `multipart/form-data` : https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#considerations-for-file-uploads
                     typeof<IO.Stream>
+                #if NET6_0_OR_GREATER
+                // According to https://swagger.io/docs/specification/data-models/data-types/#string
+                | "string", "date" -> typeof<DateOnly>
+                #endif
+                #if NETSTANDARD2_0
                 | "string", "date"
+                #endif
                 | "string", "date-time" -> typeof<DateTimeOffset>
                 | "string", "uuid" -> typeof<Guid>
                 | "string", _ -> typeof<string>


### PR DESCRIPTION
**Used Version:** 2.0.0-beta6
**Problem:**  During the work in F# Interactive notebook, I used `OpenApiClientProvider` to generate types for a V3 OpenAPI schema, but it looks like generated types don't conform our API in a certain way.
This property from YAML file:
```
  dateOfBirth:
          type: string
          format: date
          description: Person date of birth
```
is typed to `DateTimeOffset`, while official [Swagger documentation](https://swagger.io/docs/specification/data-models/data-types/#string) says it should have only date in it.

Our domain uses .Net6, so this type prop is typed this way `DateOfBirth: DateOnly`, that is more precisely mapped to Swaggers' string with date format.

I propose to use this fix for .net6 or higher version as it better conforms `full-date` criteria from [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6)