### PR TITLE
feat: update FSharp.Data utilities

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -16,8 +16,8 @@ nuget YamlDotNet
 github fsprojects/FSharp.TypeProviders.SDK src/ProvidedTypes.fsi
 github fsprojects/FSharp.TypeProviders.SDK src/ProvidedTypes.fs
 
-github fsprojects/FSharp.Data:main src/CommonRuntime/Pluralizer.fs
-github fsprojects/FSharp.Data:main src/CommonRuntime/NameUtils.fs
+github fsprojects/FSharp.Data:main src/FSharp.Data.Runtime.Utilities/Pluralizer.fs
+github fsprojects/FSharp.Data:main src/FSharp.Data.Runtime.Utilities/NameUtils.fs
 
 group Server
     source https://api.nuget.org/v3/index.json

--- a/paket.lock
+++ b/paket.lock
@@ -310,8 +310,8 @@ GITHUB
     src/ProvidedTypes.fs (6ad1174db0794a348f4a1c0aa5a60ae3f1803810)
     src/ProvidedTypes.fsi (6ad1174db0794a348f4a1c0aa5a60ae3f1803810)
   remote: fsprojects/FSharp.Data
-    src/CommonRuntime/NameUtils.fs (fd0fbccdbca7c697c8a30012754f77225b045ed1)
-    src/CommonRuntime/Pluralizer.fs (fd0fbccdbca7c697c8a30012754f77225b045ed1)
+    src/FSharp.Data.Runtime.Utilities/NameUtils.fs (2b17bea14c0ea160f9ff914b16cc5b77bfdf5e3b)
+    src/FSharp.Data.Runtime.Utilities/Pluralizer.fs (2b17bea14c0ea160f9ff914b16cc5b77bfdf5e3b)
 GROUP Server
 RESTRICTION: == net6.0
 NUGET

--- a/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
+++ b/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
@@ -13,11 +13,11 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\paket-files\fsprojects\FSharp.Data\src\CommonRuntime\Pluralizer.fs">
+    <Compile Include="..\..\paket-files\fsprojects\FSharp.Data\src\FSharp.Data.Runtime.Utilities\Pluralizer.fs">
       <Paket>True</Paket>
       <Link>paket-files/Pluralizer.fs</Link>
     </Compile>
-    <Compile Include="..\..\paket-files\fsprojects\FSharp.Data\src\CommonRuntime\NameUtils.fs">
+    <Compile Include="..\..\paket-files\fsprojects\FSharp.Data\src\FSharp.Data.Runtime.Utilities\NameUtils.fs">
       <Paket>True</Paket>
       <Link>paket-files/NameUtils.fs</Link>
     </Compile>
@@ -52,9 +52,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="6.0.5">
-        <!-- This excludes FSharp.Core.xml and FSharp.Core.resources.dll while referencing the right FSharp.Core.dll version -->
-        <ExcludeAssets>runtime;contentFiles</ExcludeAssets>
+      <!-- This excludes FSharp.Core.xml and FSharp.Core.resources.dll while referencing the right FSharp.Core.dll version -->
+      <ExcludeAssets>runtime;contentFiles</ExcludeAssets>
     </PackageReference>
-   </ItemGroup>
+  </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
The utilities we use from FSharp.Data have moved which caused `paket install` to fail. This PR updates their path. Tests still pass.

https://github.com/fsprojects/FSharp.Data/tree/main/src/FSharp.Data.Runtime.Utilities