### PR TITLE
Added missing properties to `OpenApiException`

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -21,7 +21,7 @@
       ]
     },
     "fantomas": {
-      "version": "6.0.1",
+      "version": "6.0.3",
       "commands": [
         "fantomas"
       ]

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
     - master
-    - net5
 
 jobs:
   build:

--- a/paket.lock
+++ b/paket.lock
@@ -40,8 +40,8 @@ GITHUB
     src/ProvidedTypes.fs (b7c930b0bd9e0e0476981ba0813ac17e7d61742b)
     src/ProvidedTypes.fsi (b7c930b0bd9e0e0476981ba0813ac17e7d61742b)
   remote: fsprojects/FSharp.Data
-    src/FSharp.Data.Runtime.Utilities/NameUtils.fs (ef2eda4cb33386335e25d03e694668b0af6f0945)
-    src/FSharp.Data.Runtime.Utilities/Pluralizer.fs (ef2eda4cb33386335e25d03e694668b0af6f0945)
+    src/FSharp.Data.Runtime.Utilities/NameUtils.fs (bbe54edc63a2d1ca3616f3b847ee34c0a88f91f2)
+    src/FSharp.Data.Runtime.Utilities/Pluralizer.fs (bbe54edc63a2d1ca3616f3b847ee34c0a88f91f2)
 GROUP Server
 RESTRICTION: == net6.0
 NUGET

--- a/src/SwaggerProvider.Runtime/ProvidedApiClientBase.fs
+++ b/src/SwaggerProvider.Runtime/ProvidedApiClientBase.fs
@@ -6,10 +6,12 @@ open System.Threading.Tasks
 open System.Text.Json
 open System.Text.Json.Serialization
 
-type OpenApiException(code: int, description: string) =
+type OpenApiException(code: int, description: string, headers: Headers.HttpResponseHeaders, content: HttpContent) =
     inherit Exception(description)
     member _.StatusCode = code
     member _.Description = description
+    member _.Headers = headers
+    member _.Content = content
 
 type ProvidedApiClientBase(httpClient: HttpClient, options: JsonSerializerOptions) =
 
@@ -48,7 +50,7 @@ type ProvidedApiClientBase(httpClient: HttpClient, options: JsonSerializerOption
                 |> Array.tryFindIndex((=) codeStr)
                 |> Option.iter(fun idx ->
                     let desc = errorDescriptions[idx]
-                    raise(OpenApiException(code, desc)))
+                    raise(OpenApiException(code, desc, response.Headers, response.Content)))
 
                 // fail with HttpRequestException if we do not know error description
                 return response.EnsureSuccessStatusCode().Content

--- a/tests/SwaggerProvider.Tests/paket.references
+++ b/tests/SwaggerProvider.Tests/paket.references
@@ -1,7 +1,7 @@
 group Test
     FSharp.Core
-    Microsoft.NET.Test.Sdk
+    FSharp.SystemTextJson
     FsUnit.xUnit
+    Microsoft.NET.Test.Sdk
     Microsoft.OpenApi.Readers
     System.Text.Json
-    FSharp.SystemTextJson

--- a/tests/Swashbuckle.WebApi.Server/paket.references
+++ b/tests/Swashbuckle.WebApi.Server/paket.references
@@ -1,7 +1,8 @@
 group Server
+    FSharp.Core
     Microsoft.AspNetCore
     Microsoft.AspNetCore.Mvc
     Microsoft.AspNetCore.HttpsPolicy
-    Swashbuckle.AspNetCore
     Microsoft.OpenApi
-    FSharp.Core
+    Swashbuckle.AspNetCore
+    System.Text.Json


### PR DESCRIPTION
- Headers
- Content

Content is a crucial property to expose