### PR TITLE
Add custom json formatter for `format: date`

### DIFF
--- a/src/SwaggerProvider.DesignTime/v3/DefinitionCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/v3/DefinitionCompiler.fs
@@ -263,6 +263,10 @@ type DefinitionCompiler(schema: OpenApiDocument, provideNullable) as this =
 
                         let pField, pProp = generateProperty propName pTy
 
+                        //
+                        if (schemaObj.Type, schemaObj.Format) = ("string", "date") then
+                            pProp.AddCustomAttribute(RuntimeHelpers.getDateTimeOffsetFullDateConverterAttribute())
+
                         if not <| String.IsNullOrWhiteSpace propSchema.Description then
                             pProp.AddXmlDoc propSchema.Description
 

--- a/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
+++ b/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
@@ -2,6 +2,7 @@ namespace Swagger.Internal
 
 open System
 open System.Net.Http
+open System.Text.Json
 open System.Text.Json.Serialization
 open System.Threading.Tasks
 
@@ -18,6 +19,19 @@ module MediaTypes =
     [<Literal>]
     let MultipartFormData = "multipart/form-data"
 
+type DateTimeOffsetFullDateConverter() =
+
+    inherit JsonConverter<DateTimeOffset>()
+
+    override this.Read(reader: byref<Utf8JsonReader>, _typ: Type, options: JsonSerializerOptions) =
+        DateTimeOffset.Parse(reader.GetString())
+
+    override this.Write(writer: Utf8JsonWriter, value: DateTimeOffset, options: JsonSerializerOptions) =
+        writer.WriteStringValue(
+            // full-date: date-fullyear "-" date-month "-" date-mday according to https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+            // this format is required for strings with format 'date' according to https://swagger.io/docs/specification/data-models/data-types/
+            value.ToUniversalTime().ToString("yyyy-MM-dd")
+        )
 
 type AsyncExtensions() =
     static member cast<'t> asyncOp =
@@ -120,6 +134,15 @@ module RuntimeHelpers =
 
             member _.ConstructorArguments =
                 [| Reflection.CustomAttributeTypedArgument(typeof<string>, name) |] :> Collections.Generic.IList<_>
+
+            member _.NamedArguments = [||] :> Collections.Generic.IList<_> }
+
+    let getDateTimeOffsetFullDateConverterAttribute() =
+        { new Reflection.CustomAttributeData() with
+            member _.Constructor = typeof<JsonConverterAttribute>.GetConstructor [| typeof<Type> |]
+
+            member _.ConstructorArguments =
+                [| Reflection.CustomAttributeTypedArgument(typeof<Type>, typeof<DateTimeOffsetFullDateConverter>) |] :> Collections.Generic.IList<_>
 
             member _.NamedArguments = [||] :> Collections.Generic.IList<_> }
 


### PR DESCRIPTION
See #240.

@sergey-tihon @Thorium I gave this a shot by adding a custom attribute if the format of a string in the schema is `date`.

I could not get the test projects to work locally, but i would guess i could add a controller to the swashbuckle webapi?

E.g. a `UpdateDateOnlyController` here https://github.com/fsprojects/SwaggerProvider/blob/master/tests/Swashbuckle.WebApi.Server/Controllers/UpdateControllers.fs

If you could give me guidance on where and how to add relevant tests that would be great.



