### PR TITLE
Fix: Required DateTime QueryParameter in round-trip format

### DIFF
--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+#### 2.1.2 - Jun 3, 2024
+
+  - fix: Support DateTime/DateTimeOffset as required query parameter, using round-trip format (#244)
+
 #### 2.1.1 - Apr 8, 2024
 
 - Minor dependency updates

--- a/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
+++ b/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
@@ -110,6 +110,8 @@ module RuntimeHelpers =
         | :? Option<string> as x -> x |> toStrOpt name
         | :? Option<DateTime> as x -> x |> toStrDateTimeOpt name
         | :? Option<DateTimeOffset> as x -> x |> toStrDateTimeOffsetOpt name
+        | :? DateTime as x -> [ name, x.ToString("O") ]
+        | :? DateTimeOffset as x -> [ name, x.ToString("O") ]
         | :? Option<Guid> as x -> x |> toStrOpt name
         | _ -> [ name, (if isNull obj then null else obj.ToString()) ]
 


### PR DESCRIPTION
DateTime/DateTimeOffset are not in round-trip format if they are required query parameters
#244 