### PR TITLE
Added .NET 8 runtime, updated Microsoft.OpenApi

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,6 +1,6 @@
 version 8.0.3
 source https://api.nuget.org/v3/index.json
-frameworks: net8.0, netstandard2.0
+storage: none
 
 nuget FSharp.Core ~> 6 // We need task{} CE from F# 6.0
 nuget System.Text.Json ~> 6

--- a/paket.lock
+++ b/paket.lock
@@ -1,47 +1,54 @@
-RESTRICTION: || (== net8.0) (== netstandard2.0)
+STORAGE: NONE
 NUGET
   remote: https://api.nuget.org/v3/index.json
     FSharp.Core (6.0.7)
     FSharp.SystemTextJson (1.3.13)
-      FSharp.Core (>= 4.7)
-      System.Text.Json (>= 6.0)
-    Microsoft.Bcl.AsyncInterfaces (9.0.1) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (&& (== net8.0) (>= net462)) (&& (== net8.0) (< netstandard2.1)) (== netstandard2.0)
-    Microsoft.OpenApi (1.6.23)
-    Microsoft.OpenApi.Readers (1.6.23)
-      Microsoft.OpenApi (>= 1.6.23)
-      SharpYaml (>= 2.1.1)
+      FSharp.Core (>= 4.7) - restriction: >= netstandard2.0
+      System.Text.Json (>= 6.0) - restriction: >= netstandard2.0
+    Microsoft.Bcl.AsyncInterfaces (9.0.1) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
+      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net462) (&& (>= netstandard2.0) (< netstandard2.1))
+    Microsoft.NETCore.Platforms (7.0.4) - restriction: >= net461
+    Microsoft.OpenApi (1.6.24) - restriction: >= netstandard2.0
+    Microsoft.OpenApi.Readers (1.6.24)
+      Microsoft.OpenApi (>= 1.6.24) - restriction: >= netstandard2.0
+      SharpYaml (>= 2.1.1) - restriction: >= netstandard2.0
+    NETStandard.Library (2.0.3) - restriction: >= net461
+      Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (>= net45) (< netstandard1.3)) (&& (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81)) (&& (< net45) (>= netstandard2.0)) (&& (>= net46) (< netstandard1.4)) (>= net461) (>= netcoreapp2.0) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8) (< win8)) (&& (< netstandard1.0) (< portable-net45+win8) (>= portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= portable-net45+win8+wp8+wpa81) (< portable-net45+win8+wpa81)) (&& (< netstandard1.0) (>= win8)) (&& (< netstandard1.3) (< win8) (>= wpa81)) (&& (< netstandard1.5) (>= uap10.0)) (>= uap10.1) (>= wp8)
     NETStandard.Library.NETFramework (2.0.0-preview2-25405-01)
-    SharpYaml (2.1.1)
-    System.Buffers (4.6) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (>= net462)) (&& (== net8.0) (< netcoreapp2.1)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-    System.Memory (4.6) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (>= net462)) (&& (== net8.0) (< net6.0)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-      System.Buffers (>= 4.6) - restriction: || (&& (== net8.0) (>= net462)) (&& (== net8.0) (< netcoreapp2.1)) (== netstandard2.0)
-      System.Numerics.Vectors (>= 4.6) - restriction: || (&& (== net8.0) (>= net462)) (&& (== net8.0) (< netcoreapp2.1)) (== netstandard2.0)
-      System.Runtime.CompilerServices.Unsafe (>= 6.1) - restriction: || (&& (== net8.0) (>= net462)) (&& (== net8.0) (< netcoreapp2.1)) (== netstandard2.0)
-    System.Numerics.Vectors (4.6) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (>= net462)) (&& (== net8.0) (< netcoreapp2.1)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-    System.Runtime.CompilerServices.Unsafe (6.1) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (>= net462)) (&& (== net8.0) (< net6.0)) (&& (== net8.0) (< netcoreapp2.1)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-    System.Text.Encodings.Web (9.0.1) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (< net6.0)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-      System.Buffers (>= 4.5.1) - restriction: || (&& (== net8.0) (>= net462)) (== netstandard2.0)
-      System.Memory (>= 4.5.5) - restriction: || (&& (== net8.0) (>= net462)) (== netstandard2.0)
-      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (&& (== net8.0) (>= net462)) (== netstandard2.0)
+      Microsoft.NETCore.Platforms (>= 2.0.0-preview2-25405-01) - restriction: >= net461
+      NETStandard.Library (>= 2.0.0-preview2-25401-01) - restriction: >= net461
+    SharpYaml (2.1.1) - restriction: >= netstandard2.0
+    System.Buffers (4.6) - restriction: || (>= net461) (&& (< net6.0) (>= netcoreapp3.1)) (&& (< netcoreapp2.1) (>= netstandard2.0)) (&& (< netcoreapp3.1) (>= netstandard2.0))
+    System.Memory (4.6) - restriction: || (>= net461) (&& (< net6.0) (>= netcoreapp3.1)) (&& (< netcoreapp3.1) (>= netstandard2.0))
+      System.Buffers (>= 4.6) - restriction: || (>= net462) (&& (< netcoreapp2.1) (>= netstandard2.0))
+      System.Numerics.Vectors (>= 4.6) - restriction: || (>= net462) (&& (< netcoreapp2.1) (>= netstandard2.0))
+      System.Runtime.CompilerServices.Unsafe (>= 6.1) - restriction: || (>= net462) (&& (< netcoreapp2.1) (>= netstandard2.0))
+    System.Numerics.Vectors (4.6) - restriction: || (>= net461) (&& (< netcoreapp2.1) (>= netstandard2.0)) (&& (< netcoreapp3.1) (>= netstandard2.0))
+    System.Runtime.CompilerServices.Unsafe (6.1) - restriction: || (>= net461) (&& (< net6.0) (>= netcoreapp3.1)) (&& (< netcoreapp2.1) (>= netstandard2.0)) (&& (< netcoreapp3.1) (>= netstandard2.0))
+    System.Text.Encodings.Web (9.0.1) - restriction: || (>= net461) (&& (< net6.0) (>= netcoreapp3.1)) (&& (< netcoreapp3.1) (>= netstandard2.0))
+      System.Buffers (>= 4.5.1) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
+      System.Memory (>= 4.5.5) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net462) (&& (< net8.0) (>= netstandard2.0))
     System.Text.Json (6.0.11)
-      Microsoft.Bcl.AsyncInterfaces (>= 6.0) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-      System.Buffers (>= 4.5.1) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-      System.Memory (>= 4.5.4) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-      System.Numerics.Vectors (>= 4.5) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (< net6.0)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-      System.Text.Encodings.Web (>= 6.0.1) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (< net6.0)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-    System.Threading.Tasks.Extensions (4.6) - restriction: || (&& (== net8.0) (>= net461)) (&& (== net8.0) (< netcoreapp3.1)) (== netstandard2.0)
-      System.Runtime.CompilerServices.Unsafe (>= 6.1) - restriction: || (&& (== net8.0) (>= net462)) (&& (== net8.0) (< netcoreapp2.1)) (== netstandard2.0)
+      Microsoft.Bcl.AsyncInterfaces (>= 6.0) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
+      System.Buffers (>= 4.5.1) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
+      System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
+      System.Numerics.Vectors (>= 4.5) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (&& (< net6.0) (>= netcoreapp3.1)) (&& (< netcoreapp3.1) (>= netstandard2.0))
+      System.Text.Encodings.Web (>= 6.0.1) - restriction: || (>= net461) (&& (< net6.0) (>= netcoreapp3.1)) (&& (< netcoreapp3.1) (>= netstandard2.0))
+      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
+      System.ValueTuple (>= 4.5) - restriction: >= net461
+    System.Threading.Tasks.Extensions (4.6) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0)) (&& (>= netstandard2.0) (< netstandard2.1))
+      System.Runtime.CompilerServices.Unsafe (>= 6.1) - restriction: || (>= net462) (&& (< netcoreapp2.1) (>= netstandard2.0))
+    System.ValueTuple (4.6.1) - restriction: >= net461
     YamlDotNet (16.3)
 GITHUB
   remote: fsprojects/FSharp.TypeProviders.SDK
     src/ProvidedTypes.fs (23b588d06acb8e100402523abc1d4f3f06325b8a)
     src/ProvidedTypes.fsi (23b588d06acb8e100402523abc1d4f3f06325b8a)
   remote: fsprojects/FSharp.Data
-    src/FSharp.Data.Runtime.Utilities/NameUtils.fs (a7de354df7007bd74faa7d139fabab6cc55e2f0c)
-    src/FSharp.Data.Runtime.Utilities/Pluralizer.fs (a7de354df7007bd74faa7d139fabab6cc55e2f0c)
+    src/FSharp.Data.Runtime.Utilities/NameUtils.fs (db461d259bbaba330ca0c9255e9b957043a34b84)
+    src/FSharp.Data.Runtime.Utilities/Pluralizer.fs (db461d259bbaba330ca0c9255e9b957043a34b84)
 GROUP Server
 RESTRICTION: == net9.0
 NUGET
@@ -445,7 +452,7 @@ NUGET
       Microsoft.Extensions.Options (>= 9.0.1)
     Microsoft.Net.Http.Headers (9.0.1)
       Microsoft.Extensions.Primitives (>= 9.0.1)
-    Microsoft.OpenApi (1.6.23)
+    Microsoft.OpenApi (1.6.24)
     Newtonsoft.Json (13.0.3)
     Newtonsoft.Json.Bson (1.0.3)
       Newtonsoft.Json (>= 13.0.1)
@@ -505,9 +512,9 @@ NUGET
     Microsoft.NET.Test.Sdk (17.12)
       Microsoft.CodeCoverage (>= 17.12)
       Microsoft.TestPlatform.TestHost (>= 17.12)
-    Microsoft.OpenApi (1.6.23) - redirects: force
-    Microsoft.OpenApi.Readers (1.6.23) - redirects: force
-      Microsoft.OpenApi (>= 1.6.23)
+    Microsoft.OpenApi (1.6.24) - redirects: force
+    Microsoft.OpenApi.Readers (1.6.24) - redirects: force
+      Microsoft.OpenApi (>= 1.6.24)
       SharpYaml (>= 2.1.1)
     Microsoft.Testing.Extensions.TrxReport.Abstractions (1.5.1)
       Microsoft.Testing.Platform (>= 1.5.1)

--- a/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
+++ b/src/SwaggerProvider.DesignTime/SwaggerProvider.DesignTime.fsproj
@@ -11,6 +11,7 @@
     <OutputPath>..\SwaggerProvider.Runtime\bin\$(Configuration)\typeproviders\fsharp41\</OutputPath>
     <!-- This allows the component to execute from 'bin' directory during build -->
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\paket-files\fsprojects\FSharp.Data\src\FSharp.Data.Runtime.Utilities\Pluralizer.fs">

--- a/src/SwaggerProvider.Runtime/SwaggerProvider.Runtime.fsproj
+++ b/src/SwaggerProvider.Runtime/SwaggerProvider.Runtime.fsproj
@@ -4,9 +4,10 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
     <DefineConstants>TP_RUNTIME</DefineConstants>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <ItemGroup>
@@ -29,8 +30,7 @@
   </ItemGroup>
   <Target Name="BeforeBuild">
     <MSBuild Projects="..\SwaggerProvider.DesignTime\SwaggerProvider.DesignTime.fsproj" Targets="Restore" />
-    <MSBuild Projects="..\SwaggerProvider.DesignTime\SwaggerProvider.DesignTime.fsproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=net8.0" />
-    <MSBuild Projects="..\SwaggerProvider.DesignTime\SwaggerProvider.DesignTime.fsproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=netstandard2.0" />
+    <MSBuild Projects="..\SwaggerProvider.DesignTime\SwaggerProvider.DesignTime.fsproj" Targets="Build" Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)" />
   </Target>
   <Target Name="AfterBuild">
   </Target>

--- a/src/SwaggerProvider.Runtime/paket.template
+++ b/src/SwaggerProvider.Runtime/paket.template
@@ -24,6 +24,7 @@ description
     F# Type Providers for Swagger & OpenAPI
 files
     bin/Release/netstandard2.0/SwaggerProvider.Runtime.* ==> lib/netstandard2.0
+    bin/Release/net8.0/SwaggerProvider.Runtime.* ==> lib/net8.0
     bin/Release/typeproviders/fsharp41/netstandard2.0/*.dll ==> typeproviders/fsharp41/netstandard2.0
     bin/Release/typeproviders/fsharp41/net8.0/*.dll ==> typeproviders/fsharp41/net8.0
 references


### PR DESCRIPTION
Added .NET 8 runtime, updated Microsoft.OpenApi

I have a tiny hope that this could help for the current open issues of schema parsing and runtime dlls.
