### PR TITLE
When processing the body of a request with an unsupported media type,…

### DIFF
--- a/src/SwaggerProvider.DesignTime/v3/OperationCompiler.fs
+++ b/src/SwaggerProvider.DesignTime/v3/OperationCompiler.fs
@@ -120,7 +120,14 @@ type OperationCompiler(schema: OpenApiDocument, defCompiler: DefinitionCompiler,
                         formatAndParam NoData defSchema
                     | _ ->
                         let keys = operation.RequestBody.Content.Keys |> String.concat ";"
-                        failwithf $"Operation '%s{operation.OperationId}' does not contain supported media types [%A{keys}]"
+
+                        let operationId =
+                            if String.IsNullOrWhiteSpace(operation.OperationId) then
+                                $"%s{path}/%A{opTy}"
+                            else
+                                operation.OperationId
+
+                        failwithf $"Operation '%s{operationId}' does not contain supported media types [%A{keys}]"
 
             let payloadTy = bodyFormatAndParam |> Option.map fst |> Option.defaultValue NoData
 


### PR DESCRIPTION
… and there is no OperationId defined, print the path in the error instead

refs #274 

I'm not sure what the best format is here, but this changes the error message shown when building #276 from 
```
G:\Dev\SwaggerProvider\tests\SwaggerProvider.ProviderTests\v3\Swashbuckle.ReturnControllers.Tests.fs(16,15): error FS3033: The type provider 'SwaggerProvider.OpenApiClientTypeProvider' reported an error: Operation '' does not contain supported media types ["text/plain"]
```

to
```
G:\Dev\SwaggerProvider\tests\SwaggerProvider.ProviderTests\v3\Swashbuckle.ReturnControllers.Tests.fs(16,15): error FS3033: The type provider 'SwaggerProvider.OpenApiClientTypeProvider' reported an error: Operation '/api/ConsumesText/Post' does not contain supported media types ["text/plain"]
```

(```Operation '/api/ConsumesText/Post'``` rather than ```Operation ''```)