### PR TITLE
[Repo Assist] Fix Option types sending `Some(value)` in form data bodies

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.103",
-    "rollForward": "minor"
+    "version": "10.0.100",
+    "rollForward": "latestPatch"
   }
 }

--- a/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
+++ b/src/SwaggerProvider.Runtime/RuntimeHelpers.fs
@@ -145,6 +145,22 @@ module RuntimeHelpers =
             content
         | _ -> failwith $"Unexpected parameter type {boxedStream.GetType().Name} instead of IO.Stream"
 
+    // Unwraps F# option values: returns the inner value for Some, null for None.
+    // This prevents `Some(value)` from being sent as-is in form data.
+    let private unwrapFSharpOption(value: obj) : obj =
+        if isNull value then
+            null
+        else
+            let ty = value.GetType()
+
+            if
+                ty.IsGenericType
+                && ty.GetGenericTypeDefinition() = typedefof<option<_>>
+            then
+                ty.GetProperty("Value").GetValue(value)
+            else
+                value
+
     let getPropertyValues(object: obj) =
         if isNull object then
             Seq.empty
@@ -162,6 +178,7 @@ module RuntimeHelpers =
                     | _ -> prop.Name
 
                 prop.GetValue(object)
+                |> unwrapFSharpOption
                 |> Option.ofObj
                 |> Option.map(fun value -> (name, value)))
 


### PR DESCRIPTION
(Manually created repo-assist PR, by clicking link provided in issue, after checking global.json update is ok)

RuntimeHelpers.getPropertyValues now strips the FSharpOption<T> wrapper before returning property values. Previously, a property set to Some(true) was serialised as the string "Some(true)" in multipart/form-data and application/x-www-form-urlencoded bodies instead of the bare "True". None values were already handled (null).

Also relax global.json SDK version constraint from 10.0.103 to 10.0.100 with rollForward:latestPatch so the project builds with any 10.0.1xx SDK available locally or in CI.