### PR TITLE
[Repo Assist] eng: add Dependabot for GitHub Actions + v3 OperationCompiler unit tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "enhancement"

--- a/tests/SwaggerProvider.Tests/SwaggerProvider.Tests.fsproj
+++ b/tests/SwaggerProvider.Tests/SwaggerProvider.Tests.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="v3\Schema.TypeMappingTests.fs" />
     <Compile Include="v3\Schema.ArrayAndMapTypeMappingTests.fs" />
     <Compile Include="v3\Schema.V2SchemaCompilationTests.fs" />
+    <Compile Include="v3\Schema.OperationCompilationTests.fs" />
     <Compile Include="v3\Schema.XmlDocTests.fs" />
     <Compile Include="PathResolutionTests.fs" />
     <Compile Include="SsrfSecurityTests.fs" />

--- a/tests/SwaggerProvider.Tests/v3/Schema.OperationCompilationTests.fs
+++ b/tests/SwaggerProvider.Tests/v3/Schema.OperationCompilationTests.fs
@@ -7,40 +7,13 @@ open System
 open System.Reflection
 open System.Threading
 open System.Threading.Tasks
-open Microsoft.OpenApi.Reader
-open SwaggerProvider.Internal.v3.Compilers
 open Xunit
 open FsUnitTyped
 
-// ── Shared helpers ────────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
-let private compileV3Schema(yamlSchema: string) =
-    let settings = OpenApiReaderSettings()
-    settings.AddYamlReader()
-
-    let readResult =
-        Microsoft.OpenApi.OpenApiDocument.Parse(yamlSchema, settings = settings)
-
-    match readResult.Diagnostic with
-    | null -> ()
-    | diagnostic when diagnostic.Errors |> Seq.isEmpty |> not ->
-        let errorText =
-            diagnostic.Errors
-            |> Seq.map string
-            |> String.concat Environment.NewLine
-
-        failwithf "Failed to parse OpenAPI schema:%s%s" Environment.NewLine errorText
-    | _ -> ()
-
-    let schema =
-        match readResult.Document with
-        | null -> failwith "Failed to parse OpenAPI schema: Document is null."
-        | doc -> doc
-
-    let defCompiler = DefinitionCompiler(schema, false, false)
-    let opCompiler = OperationCompiler(schema, defCompiler, true, false, false)
-    opCompiler.CompileProvidedClients(defCompiler.Namespace)
-    defCompiler.Namespace.GetProvidedTypes()
+let private compileTaskSchema schemaStr =
+    compileV3Schema schemaStr false
 
 let private findMethod (types: ProviderImplementation.ProvidedTypes.ProvidedTypeDefinition list) (methodName: string) =
     types
@@ -72,13 +45,13 @@ components:
 
 [<Fact>]
 let ``GET endpoint generates a method with the operation name``() =
-    let types = compileV3Schema simpleGetSchema
+    let types = compileTaskSchema simpleGetSchema
     let method = findMethod types "GetStatus"
     method.IsSome |> shouldEqual true
 
 [<Fact>]
 let ``GET endpoint with no parameters has CancellationToken as its only parameter``() =
-    let types = compileV3Schema simpleGetSchema
+    let types = compileTaskSchema simpleGetSchema
     let method = (findMethod types "GetStatus").Value
     let parameters = method.GetParameters()
     parameters.Length |> shouldEqual 1
@@ -86,7 +59,7 @@ let ``GET endpoint with no parameters has CancellationToken as its only paramete
 
 [<Fact>]
 let ``GET endpoint returning JSON string has Task<string> return type``() =
-    let types = compileV3Schema simpleGetSchema
+    let types = compileTaskSchema simpleGetSchema
     let method = (findMethod types "GetStatus").Value
 
     method.ReturnType.IsGenericType |> shouldEqual true
@@ -130,7 +103,7 @@ components:
 
 [<Fact>]
 let ``GET with required + optional params orders required before optional``() =
-    let types = compileV3Schema parametrisedGetSchema
+    let types = compileTaskSchema parametrisedGetSchema
     let method = (findMethod types "GetItem").Value
     let parameters = method.GetParameters()
     // Expected: id (required int64), tag (optional string), cancellationToken (CT)
@@ -149,7 +122,7 @@ let ``GET with required + optional params orders required before optional``() =
 
 [<Fact>]
 let ``CancellationToken is always the last parameter``() =
-    let types = compileV3Schema parametrisedGetSchema
+    let types = compileTaskSchema parametrisedGetSchema
     let method = (findMethod types "GetItem").Value
     let parameters = method.GetParameters()
     let last = parameters |> Array.last
@@ -189,7 +162,7 @@ components:
 
 [<Fact>]
 let ``POST with body generates method with body parameter before CancellationToken``() =
-    let types = compileV3Schema postWithBodySchema
+    let types = compileTaskSchema postWithBodySchema
     let method = (findMethod types "CreateItem").Value
     let parameters = method.GetParameters()
     // Expected: body (required NewItem), cancellationToken (CT)
@@ -202,7 +175,7 @@ let ``POST with body generates method with body parameter before CancellationTok
 
 [<Fact>]
 let ``POST with no response body has Task<unit> return type``() =
-    let types = compileV3Schema postWithBodySchema
+    let types = compileTaskSchema postWithBodySchema
     let method = (findMethod types "CreateItem").Value
 
     method.ReturnType.IsGenericType |> shouldEqual true
@@ -238,7 +211,7 @@ components:
 
 [<Fact>]
 let ``when a query param is named cancellationToken the injected CT param gets a unique name``() =
-    let types = compileV3Schema ctCollisionSchema
+    let types = compileTaskSchema ctCollisionSchema
     let method = (findMethod types "Search").Value
     let parameters = method.GetParameters()
     // There should be two parameters: the query param + the CT param
@@ -282,7 +255,7 @@ components:
 
 [<Fact>]
 let ``multiple operations each generate a method with CancellationToken``() =
-    let types = compileV3Schema multiOpSchema
+    let types = compileTaskSchema multiOpSchema
 
     let listPets = findMethod types "ListPets"
     let createPet = findMethod types "CreatePet"

--- a/tests/SwaggerProvider.Tests/v3/Schema.OperationCompilationTests.fs
+++ b/tests/SwaggerProvider.Tests/v3/Schema.OperationCompilationTests.fs
@@ -1,0 +1,300 @@
+module SwaggerProvider.Tests.v3_Schema_OperationCompilationTests
+
+/// Unit tests for the v3 OperationCompiler — verifying generated method signatures,
+/// parameter ordering, CancellationToken injection, and return-type resolution.
+
+open System
+open System.Reflection
+open System.Threading
+open System.Threading.Tasks
+open Microsoft.OpenApi.Reader
+open SwaggerProvider.Internal.v3.Compilers
+open Xunit
+open FsUnitTyped
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+let private compileV3Schema(yamlSchema: string) =
+    let settings = OpenApiReaderSettings()
+    settings.AddYamlReader()
+
+    let readResult =
+        Microsoft.OpenApi.OpenApiDocument.Parse(yamlSchema, settings = settings)
+
+    match readResult.Diagnostic with
+    | null -> ()
+    | diagnostic when diagnostic.Errors |> Seq.isEmpty |> not ->
+        let errorText =
+            diagnostic.Errors
+            |> Seq.map string
+            |> String.concat Environment.NewLine
+
+        failwithf "Failed to parse OpenAPI schema:%s%s" Environment.NewLine errorText
+    | _ -> ()
+
+    let schema =
+        match readResult.Document with
+        | null -> failwith "Failed to parse OpenAPI schema: Document is null."
+        | doc -> doc
+
+    let defCompiler = DefinitionCompiler(schema, false, false)
+    let opCompiler = OperationCompiler(schema, defCompiler, true, false, false)
+    opCompiler.CompileProvidedClients(defCompiler.Namespace)
+    defCompiler.Namespace.GetProvidedTypes()
+
+let private findMethod (types: ProviderImplementation.ProvidedTypes.ProvidedTypeDefinition list) (methodName: string) =
+    types
+    |> List.collect(fun t -> t.GetMethods() |> Array.toList)
+    |> List.tryFind(fun m -> m.Name = methodName)
+
+// ── Simple GET with no parameters ─────────────────────────────────────────────
+
+let private simpleGetSchema =
+    """openapi: "3.0.0"
+info:
+  title: SimpleGetTest
+  version: "1.0.0"
+paths:
+  /status:
+    get:
+      operationId: getStatus
+      summary: Get server status
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+components:
+  schemas: {}
+"""
+
+[<Fact>]
+let ``GET endpoint generates a method with the operation name``() =
+    let types = compileV3Schema simpleGetSchema
+    let method = findMethod types "GetStatus"
+    method.IsSome |> shouldEqual true
+
+[<Fact>]
+let ``GET endpoint with no parameters has CancellationToken as its only parameter``() =
+    let types = compileV3Schema simpleGetSchema
+    let method = (findMethod types "GetStatus").Value
+    let parameters = method.GetParameters()
+    parameters.Length |> shouldEqual 1
+    parameters[0].ParameterType |> shouldEqual typeof<CancellationToken>
+
+[<Fact>]
+let ``GET endpoint returning JSON string has Task<string> return type``() =
+    let types = compileV3Schema simpleGetSchema
+    let method = (findMethod types "GetStatus").Value
+
+    method.ReturnType.IsGenericType |> shouldEqual true
+
+    method.ReturnType.GetGenericTypeDefinition()
+    |> shouldEqual typedefof<Task<_>>
+
+    method.ReturnType.GetGenericArguments()[0]
+    |> shouldEqual typeof<string>
+
+// ── GET with required and optional path/query parameters ──────────────────────
+
+let private parametrisedGetSchema =
+    """openapi: "3.0.0"
+info:
+  title: ParameterisedGetTest
+  version: "1.0.0"
+paths:
+  /items/{id}:
+    get:
+      operationId: getItem
+      summary: Get item by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: tag
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+components:
+  schemas: {}
+"""
+
+[<Fact>]
+let ``GET with required + optional params orders required before optional``() =
+    let types = compileV3Schema parametrisedGetSchema
+    let method = (findMethod types "GetItem").Value
+    let parameters = method.GetParameters()
+    // Expected: id (required int64), tag (optional string), cancellationToken (CT)
+    parameters.Length |> shouldEqual 3
+
+    let idParam = parameters[0]
+    let tagParam = parameters[1]
+    let ctParam = parameters[2]
+
+    idParam.Name |> shouldEqual "id"
+    idParam.ParameterType |> shouldEqual typeof<int64>
+    // optional — marked as optional via ParameterAttributes
+    tagParam.Name |> shouldEqual "tag"
+    tagParam.IsOptional |> shouldEqual true
+    ctParam.ParameterType |> shouldEqual typeof<CancellationToken>
+
+[<Fact>]
+let ``CancellationToken is always the last parameter``() =
+    let types = compileV3Schema parametrisedGetSchema
+    let method = (findMethod types "GetItem").Value
+    let parameters = method.GetParameters()
+    let last = parameters |> Array.last
+    last.ParameterType |> shouldEqual typeof<CancellationToken>
+
+// ── POST with JSON request body ───────────────────────────────────────────────
+
+let private postWithBodySchema =
+    """openapi: "3.0.0"
+info:
+  title: PostBodyTest
+  version: "1.0.0"
+paths:
+  /items:
+    post:
+      operationId: createItem
+      summary: Create a new item
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewItem'
+      responses:
+        "201":
+          description: Created
+components:
+  schemas:
+    NewItem:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+"""
+
+[<Fact>]
+let ``POST with body generates method with body parameter before CancellationToken``() =
+    let types = compileV3Schema postWithBodySchema
+    let method = (findMethod types "CreateItem").Value
+    let parameters = method.GetParameters()
+    // Expected: body (required NewItem), cancellationToken (CT)
+    parameters.Length |> shouldEqual 2
+    let bodyParam = parameters[0]
+    let ctParam = parameters[1]
+    // Body parameter is a provided type, so just verify it is not CancellationToken
+    bodyParam.ParameterType |> shouldNotEqual typeof<CancellationToken>
+    ctParam.ParameterType |> shouldEqual typeof<CancellationToken>
+
+[<Fact>]
+let ``POST with no response body has Task<unit> return type``() =
+    let types = compileV3Schema postWithBodySchema
+    let method = (findMethod types "CreateItem").Value
+
+    method.ReturnType.IsGenericType |> shouldEqual true
+
+    method.ReturnType.GetGenericTypeDefinition()
+    |> shouldEqual typedefof<Task<_>>
+
+    method.ReturnType.GetGenericArguments()[0] |> shouldEqual typeof<unit>
+
+// ── CancellationToken naming collision avoidance ──────────────────────────────
+
+let private ctCollisionSchema =
+    """openapi: "3.0.0"
+info:
+  title: CTCollisionTest
+  version: "1.0.0"
+paths:
+  /search:
+    get:
+      operationId: search
+      parameters:
+        - name: cancellationToken
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+components:
+  schemas: {}
+"""
+
+[<Fact>]
+let ``when a query param is named cancellationToken the injected CT param gets a unique name``() =
+    let types = compileV3Schema ctCollisionSchema
+    let method = (findMethod types "Search").Value
+    let parameters = method.GetParameters()
+    // There should be two parameters: the query param + the CT param
+    parameters.Length |> shouldEqual 2
+    let ctParam = parameters |> Array.last
+    // The injected CT param must not collide with the API param name
+    ctParam.ParameterType |> shouldEqual typeof<CancellationToken>
+    ctParam.Name |> shouldNotEqual parameters[0].Name
+
+// ── Multiple operations — each gets its own CT parameter ─────────────────────
+
+let private multiOpSchema =
+    """openapi: "3.0.0"
+info:
+  title: MultiOpTest
+  version: "1.0.0"
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: OK
+    post:
+      operationId: createPet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        "201":
+          description: Created
+components:
+  schemas: {}
+"""
+
+[<Fact>]
+let ``multiple operations each generate a method with CancellationToken``() =
+    let types = compileV3Schema multiOpSchema
+
+    let listPets = findMethod types "ListPets"
+    let createPet = findMethod types "CreatePet"
+
+    listPets.IsSome |> shouldEqual true
+    createPet.IsSome |> shouldEqual true
+
+    let listPetsParams = listPets.Value.GetParameters()
+    let createPetParams = createPet.Value.GetParameters()
+
+    (listPetsParams |> Array.last).ParameterType
+    |> shouldEqual typeof<CancellationToken>
+
+    (createPetParams |> Array.last).ParameterType
+    |> shouldEqual typeof<CancellationToken>

--- a/tests/SwaggerProvider.Tests/v3/Schema.TestHelpers.fs
+++ b/tests/SwaggerProvider.Tests/v3/Schema.TestHelpers.fs
@@ -5,9 +5,9 @@ open System
 open Microsoft.OpenApi.Reader
 open SwaggerProvider.Internal.v3.Compilers
 
-/// Parse and compile a full OpenAPI v3 schema string, then return the .NET type of
-/// the `Value` property on the `TestType` component schema.
-let compileSchemaAndGetValueType(schemaStr: string) : Type =
+/// Parse and compile a full OpenAPI v3 schema string, then return all provided types.
+/// Pass asAsync=true to generate Async<'T> operation return types, or false for Task<'T>.
+let compileV3Schema (schemaStr: string) (asAsync: bool) =
     let settings = OpenApiReaderSettings()
     settings.AddYamlReader()
 
@@ -31,10 +31,14 @@ let compileSchemaAndGetValueType(schemaStr: string) : Type =
         | doc -> doc
 
     let defCompiler = DefinitionCompiler(schema, false, false)
-    let opCompiler = OperationCompiler(schema, defCompiler, true, false, true)
+    let opCompiler = OperationCompiler(schema, defCompiler, true, false, asAsync)
     opCompiler.CompileProvidedClients(defCompiler.Namespace)
+    defCompiler.Namespace.GetProvidedTypes()
 
-    let types = defCompiler.Namespace.GetProvidedTypes()
+/// Parse and compile a full OpenAPI v3 schema string, then return the .NET type of
+/// the `Value` property on the `TestType` component schema.
+let compileSchemaAndGetValueType(schemaStr: string) : Type =
+    let types = compileV3Schema schemaStr false
     let testType = types |> List.find(fun t -> t.Name = "TestType")
 
     match testType.GetDeclaredProperty("Value") with


### PR DESCRIPTION
Task 4 (Engineering Investments):
- Add .github/dependabot.yml to enable weekly Dependabot alerts for GitHub Actions version updates (checkout, setup-dotnet, cache).

Task 9 (Testing Improvements):
- Add Schema.OperationCompilationTests.fs with 9 unit tests covering the v3 OperationCompiler pipeline:
  - Simple GET generates a correctly named method
  - No-parameter GET has CancellationToken as sole parameter
  - Task<string> return type for JSON string response
  - Required params come before optional ones in method signature
  - CancellationToken is always last regardless of param count
  - POST with body: body param precedes CancellationToken
  - POST with 201/no-body returns Task<unit>
  - CT name deduplication when a query param is named cancellationToken
  - Multiple operations each get their own CancellationToken param

All 272 unit tests pass (0 failures, 2 pre-existing skips). Format verified with Fantomas.