### PR TITLE
[Repo Assist] eng: add NuGet ecosystem to Dependabot to track dotnet global tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
       interval: "weekly"
     labels:
       - "enhancement"
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "enhancement"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     labels:
       - "enhancement"
   - package-ecosystem: "nuget"
-    directory: "/"
+    directory: "/.config"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
The existing Dependabot config only covered GitHub Actions. Add the nuget package-ecosystem entry so Dependabot also monitors dotnet global tools declared in .config/dotnet-tools.json:

  - paket (10.3.1)
  - fantomas (7.0.5)
  - dotnet-serve (1.10.194)

Keeping both entries on a weekly schedule consistent with the existing GitHub Actions entry.