### PR TITLE
[Repo Assist] eng: update global.json SDK from 10.0.102 to 10.0.201

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.102",
+    "version": "10.0.201",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
The installed SDK is 10.0.201. With rollForward:latestMinor the old minimum (10.0.102) was already satisfied, but bumping the pinned version keeps the file in sync with the actual runtime in use.