### PR TITLE
[repo-assist] chore: update global.json SDK baseline from 10.0.201 to 10.0.301

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.201",
+    "version": "10.0.301",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
The rollForward=latestMinor policy already selects the latest available
10.x SDK at build time. This change updates the pinned baseline to the
version running in CI and local development, keeping the documented
minimum in sync with current usage.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
